### PR TITLE
fix: Register yurtle_rdflib plugin for RDF frontmatter parsing

### DIFF
--- a/src/yurtle_kanban/__init__.py
+++ b/src/yurtle_kanban/__init__.py
@@ -23,6 +23,13 @@ Usage:
 
 __version__ = "0.1.0"
 
+# Register yurtle_rdflib plugin with rdflib (enables format="yurtle" parsing)
+# This must be imported before any rdflib Graph.parse() calls with format="yurtle"
+try:
+    import yurtle_rdflib  # noqa: F401
+except ImportError:
+    pass  # yurtle_rdflib is optional; YAML frontmatter still works without it
+
 from yurtle_kanban.config import KanbanConfig
 from yurtle_kanban.models import (
     Board,


### PR DESCRIPTION
## Summary

- Fixes RDF/Turtle frontmatter parsing by importing `yurtle_rdflib` at package init
- The import registers the "yurtle" format plugin with rdflib
- Wrapped in try/except so YAML frontmatter still works without yurtle_rdflib

## Problem

`indexer.py` uses `g.parse(file_path, format="yurtle")` but the "yurtle" format plugin wasn't registered because `yurtle_rdflib` was never imported. This caused files with RDF/Turtle frontmatter (starting with `@prefix`) to fail parsing silently.

## Test plan

- [x] Verify YAML frontmatter still works
- [x] Verify RDF frontmatter now parses correctly when yurtle_rdflib is installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)