### PR TITLE
fix: resolve shared data paths for pip-installed environments

### DIFF
--- a/src/yurtle_kanban/cli.py
+++ b/src/yurtle_kanban/cli.py
@@ -40,39 +40,45 @@ from .hdd_commands import experiment, hypothesis, idea, literature, measure, pap
 from .service import KanbanService
 
 
-def _get_templates_dir() -> Path:
-    """Get the path to the templates directory in the package."""
-    # Templates are at the package root level (not in src/)
+def _get_shared_data_dir(subdir: str) -> Path:
+    """Get the path to a shared data directory (templates, skills, themes).
+
+    Searches in priority order:
+    1. Package share directory (pip installed via Hatchling → share/yurtle-kanban/)
+    2. Development source repo (subdir at repo root)
+    3. Fallback relative to this file
+    """
+    import sys
+
+    # Priority 1: Package share directory (pip installed via Hatchling)
+    for path in sys.path:
+        share_path = Path(path).parent / "share" / "yurtle-kanban" / subdir
+        if share_path.exists():
+            return share_path
+
+    # Priority 2: Development source repo (subdir at repo root)
     try:
         import yurtle_kanban
 
         package_dir = Path(yurtle_kanban.__file__).parent.parent.parent
-        templates_dir = package_dir / "templates"
-        if templates_dir.exists():
-            return templates_dir
+        dev_dir = package_dir / subdir
+        if dev_dir.exists():
+            return dev_dir
     except Exception:
         pass
 
-    # Fallback: try relative to this file
-    templates_dir = Path(__file__).parent.parent.parent / "templates"
-    return templates_dir
+    # Fallback: relative to this file
+    return Path(__file__).parent.parent.parent / subdir
+
+
+def _get_templates_dir() -> Path:
+    """Get the path to the templates directory in the package."""
+    return _get_shared_data_dir("templates")
 
 
 def _get_skills_dir() -> Path:
     """Get the path to the skills directory in the package."""
-    try:
-        import yurtle_kanban
-
-        package_dir = Path(yurtle_kanban.__file__).parent.parent.parent
-        skills_dir = package_dir / "skills"
-        if skills_dir.exists():
-            return skills_dir
-    except Exception:
-        pass
-
-    # Fallback: try relative to this file
-    skills_dir = Path(__file__).parent.parent.parent / "skills"
-    return skills_dir
+    return _get_shared_data_dir("skills")
 
 
 console = Console()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4,7 +4,27 @@ import yaml
 from pathlib import Path
 from click.testing import CliRunner
 
-from yurtle_kanban.cli import main
+from yurtle_kanban.cli import main, _get_templates_dir, _get_skills_dir
+
+
+class TestSharedDataResolution:
+    """_get_templates_dir() and _get_skills_dir() should find shared data (#19)."""
+
+    def test_get_templates_dir_finds_templates(self):
+        """Templates dir should exist and contain expected theme subdirs."""
+        templates_dir = _get_templates_dir()
+        assert templates_dir.exists(), f"templates dir not found: {templates_dir}"
+        # Should contain at least the standard themes
+        for theme in ("hdd", "nautical", "software"):
+            assert (templates_dir / theme).is_dir(), f"Missing theme subdir: {theme}"
+
+    def test_get_skills_dir_finds_skills(self):
+        """Skills dir should exist and contain expected theme subdirs."""
+        skills_dir = _get_skills_dir()
+        assert skills_dir.exists(), f"skills dir not found: {skills_dir}"
+        # Should contain at least the standard themes
+        for theme in ("hdd", "nautical", "software"):
+            assert (skills_dir / theme).is_dir(), f"Missing theme subdir: {theme}"
 
 
 class TestInitScaffolding:


### PR DESCRIPTION
## Summary

- `_get_templates_dir()` and `_get_skills_dir()` resolved to wrong paths in pip-installed environments (`.venv/lib/python3.11/templates/` instead of `.venv/share/yurtle-kanban/templates/`)
- Extract `_get_shared_data_dir()` using the search strategy already proven in `config.py` `_load_builtin_theme()`: check `share/yurtle-kanban/` via `sys.path`, then dev source fallback
- Add 2 path resolution tests to `test_init.py`

## Test plan

- [x] 269/269 existing tests pass
- [x] 2 new `TestSharedDataResolution` tests verify templates and skills dirs are found with correct theme subdirs (hdd, nautical, software)
- [ ] After merge: reinstall in nusy venv, remove symlink workaround, verify `hypothesis create` finds template

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)