### PR TITLE
fix: route HDD item types to correct board in multi-board mode

### DIFF
--- a/src/yurtle_kanban/service.py
+++ b/src/yurtle_kanban/service.py
@@ -499,21 +499,39 @@ class KanbanService:
 
         return sorted(items, key=lambda i: (-i.priority_score, i.id))
 
-    def _get_type_directory(self, item_type: WorkItemType) -> Path:
+    def _get_type_directory(self, item_type: WorkItemType, board_name: str | None = None) -> Path:
         """Get the directory for placing a file of this item type.
 
         Resolution order:
         1. Theme item_types[type].path (explicit per-type directory)
+           In multi-board mode, searches all boards' themes for the type.
         2. PathConfig attributes (features, bugs, epics, tasks)
         3. scan_paths keyword match (e.g., "expeditions/" for expedition type)
         4. Fall back to paths.root
         """
         # Priority 1: Theme-defined path
-        theme = self.config.get_theme()
-        if theme and "item_types" in theme:
-            type_def = theme["item_types"].get(item_type.value, {})
-            if "path" in type_def:
-                return self.repo_root / type_def["path"]
+        if self.config.is_multi_board:
+            # Multi-board: check specific board or search all boards
+            if board_name:
+                theme = self.config.get_theme(board_name)
+                if theme and "item_types" in theme:
+                    type_def = theme["item_types"].get(item_type.value, {})
+                    if "path" in type_def:
+                        return self.repo_root / type_def["path"]
+            else:
+                # Search all boards for a theme that defines this item type
+                for board in self.config.boards:
+                    board_theme = board.get_theme(self.repo_root)
+                    if board_theme and "item_types" in board_theme:
+                        type_def = board_theme["item_types"].get(item_type.value, {})
+                        if "path" in type_def:
+                            return self.repo_root / type_def["path"]
+        else:
+            theme = self.config.get_theme()
+            if theme and "item_types" in theme:
+                type_def = theme["item_types"].get(item_type.value, {})
+                if "path" in type_def:
+                    return self.repo_root / type_def["path"]
 
         # Priority 2: Legacy PathConfig attributes (features, bugs, epics, tasks)
         type_path = getattr(self.config.paths, item_type.value + "s", None)

--- a/tests/test_multiboard.py
+++ b/tests/test_multiboard.py
@@ -395,3 +395,157 @@ class TestBoardForPath:
             repo_root=tmp_path,
         )
         assert board is None
+
+
+class TestHDDTypeRoutingMultiBoard:
+    """Issue #20: HDD item types must route to the research board in multi-board mode.
+
+    When a multi-board config has development (nautical) + research (hdd) boards,
+    HDD item types (hypothesis, experiment, literature, measure, paper, idea)
+    should be created in the research board's directories, not the development board's.
+    """
+
+    @pytest.fixture
+    def multiboard_hdd_setup(self, tmp_path):
+        """Create a multi-board environment with development + research boards."""
+        import subprocess
+
+        # Init git repo (needed for create_item_and_push)
+        subprocess.run(["git", "init", "-b", "main"], cwd=tmp_path, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=tmp_path, capture_output=True, check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test"],
+            cwd=tmp_path, capture_output=True, check=True,
+        )
+
+        # Create config
+        config_path = tmp_path / ".kanban" / "config.yaml"
+        config_path.parent.mkdir(parents=True)
+        config_path.write_text("""
+version: "2.0"
+boards:
+  - name: development
+    preset: nautical
+    path: kanban-work/
+  - name: research
+    preset: hdd
+    path: research/
+default_board: development
+""")
+
+        # Create directory structure
+        for subdir in ["expeditions", "chores", "voyages"]:
+            (tmp_path / "kanban-work" / subdir).mkdir(parents=True)
+        for subdir in ["ideas", "literature", "papers", "hypotheses", "experiments", "measures"]:
+            (tmp_path / "research" / subdir).mkdir(parents=True)
+
+        config = KanbanConfig.load(config_path)
+        service = KanbanService(config, tmp_path)
+
+        return {"tmp_path": tmp_path, "config": config, "service": service}
+
+    def test_hypothesis_routes_to_research(self, multiboard_hdd_setup):
+        """Hypothesis should be created in research/hypotheses/, not kanban-work/."""
+        from yurtle_kanban.models import WorkItemType
+
+        service = multiboard_hdd_setup["service"]
+        tmp_path = multiboard_hdd_setup["tmp_path"]
+
+        item = service.create_item(
+            item_type=WorkItemType.HYPOTHESIS,
+            title="V12 improves accuracy",
+            item_id="H130.1",
+        )
+
+        assert "research/hypotheses/" in str(item.file_path)
+        assert "kanban-work" not in str(item.file_path)
+        assert item.file_path.exists()
+
+    def test_experiment_routes_to_research(self, multiboard_hdd_setup):
+        """Experiment should be created in research/experiments/."""
+        from yurtle_kanban.models import WorkItemType
+
+        service = multiboard_hdd_setup["service"]
+
+        item = service.create_item(
+            item_type=WorkItemType.EXPERIMENT,
+            title="V12 accuracy test",
+            item_id="EXPR-130",
+        )
+
+        assert "research/experiments/" in str(item.file_path)
+        assert "kanban-work" not in str(item.file_path)
+
+    def test_paper_routes_to_research(self, multiboard_hdd_setup):
+        """Paper should be created in research/papers/."""
+        from yurtle_kanban.models import WorkItemType
+
+        service = multiboard_hdd_setup["service"]
+
+        item = service.create_item(
+            item_type=WorkItemType.PAPER,
+            title="NuSy Brain Architecture",
+            item_id="PAPER-130",
+        )
+
+        assert "research/papers/" in str(item.file_path)
+
+    def test_literature_routes_to_research(self, multiboard_hdd_setup):
+        """Literature should be created in research/literature/."""
+        from yurtle_kanban.models import WorkItemType
+
+        service = multiboard_hdd_setup["service"]
+
+        item = service.create_item(
+            item_type=WorkItemType.LITERATURE,
+            title="Transfer learning survey",
+            item_id="LIT-001",
+        )
+
+        assert "research/literature/" in str(item.file_path)
+
+    def test_measure_routes_to_research(self, multiboard_hdd_setup):
+        """Measure should be created in research/measures/."""
+        from yurtle_kanban.models import WorkItemType
+
+        service = multiboard_hdd_setup["service"]
+
+        item = service.create_item(
+            item_type=WorkItemType.MEASURE,
+            title="Reasoning Accuracy",
+            item_id="M-001",
+        )
+
+        assert "research/measures/" in str(item.file_path)
+
+    def test_idea_routes_to_research(self, multiboard_hdd_setup):
+        """Idea should be created in research/ideas/."""
+        from yurtle_kanban.models import WorkItemType
+
+        service = multiboard_hdd_setup["service"]
+
+        item = service.create_item(
+            item_type=WorkItemType.IDEA,
+            title="Explore transfer learning",
+            item_id="IDEA-R-001",
+        )
+
+        assert "research/ideas/" in str(item.file_path)
+
+    def test_expedition_still_routes_to_kanban_work(self, multiboard_hdd_setup):
+        """Nautical types should still route to kanban-work/, not research/."""
+        from yurtle_kanban.models import WorkItemType
+
+        service = multiboard_hdd_setup["service"]
+
+        item = service.create_item(
+            item_type=WorkItemType.EXPEDITION,
+            title="Test expedition",
+            item_id="EXP-999",
+        )
+
+        assert "kanban-work" in str(item.file_path)
+        assert "research" not in str(item.file_path)


### PR DESCRIPTION
## Summary

Fixes #20 — HDD item types (hypothesis, experiment, literature, measure, paper, idea) were being created in `kanban-work/` instead of `research/` when using multi-board configuration.

- **Root cause**: `_get_type_directory()` called `get_theme()` without board context, always getting the default board's theme (nautical), which has no HDD type definitions — falling through to the default `kanban-work/` path
- **Fix**: In multi-board mode, `_get_type_directory()` now searches all boards' themes for a matching type definition. The HDD theme on the research board defines the correct paths (`research/hypotheses/`, `research/experiments/`, etc.)
- Also adds optional `board_name` parameter for explicit board targeting

## Test plan

- [x] 7 new tests in `TestHDDTypeRoutingMultiBoard` covering all 6 HDD types + nautical type regression
- [x] Full test suite passes (274/274)
- [ ] Manual verification in nusy-product-team with `hypothesis create --push`

🤖 Generated with [Claude Code](https://claude.com/claude-code)