### PR TITLE
fix: use sys.prefix for shared data resolution

### DIFF
--- a/src/yurtle_kanban/cli.py
+++ b/src/yurtle_kanban/cli.py
@@ -50,11 +50,10 @@ def _get_shared_data_dir(subdir: str) -> Path:
     """
     import sys
 
-    # Priority 1: Package share directory (pip installed via Hatchling)
-    for path in sys.path:
-        share_path = Path(path).parent / "share" / "yurtle-kanban" / subdir
-        if share_path.exists():
-            return share_path
+    # Priority 1: sys.prefix (standard for venv/conda — Hatchling installs here)
+    share_path = Path(sys.prefix) / "share" / "yurtle-kanban" / subdir
+    if share_path.exists():
+        return share_path
 
     # Priority 2: Development source repo (subdir at repo root)
     try:
@@ -226,9 +225,22 @@ kanban:
         skills_dst = repo_root / ".claude" / "skills"
         skills_dst.mkdir(parents=True, exist_ok=True)
 
-        # Copy theme-neutral skills (sync, status, release)
+        # Theme directories contain sub-skills (e.g., nautical/expedition/SKILL.md).
+        # Detect theme dirs and their owned skills to avoid copying theme-specific
+        # skills as theme-neutral (can happen with stale pip installs).
+        theme_dirs: set[str] = set()
+        theme_owned_skills: set[str] = set()
+        for d in skills_src.iterdir():
+            if d.is_dir() and any(sub.is_dir() for sub in d.iterdir()):
+                theme_dirs.add(d.name)
+                for sub in d.iterdir():
+                    if sub.is_dir():
+                        theme_owned_skills.add(sub.name)
+        skip = theme_dirs | theme_owned_skills
+
+        # Copy theme-neutral skills (sync, status, release, etc.)
         for skill_dir in skills_src.iterdir():
-            if skill_dir.is_dir() and skill_dir.name not in ("nautical", "software"):
+            if skill_dir.is_dir() and skill_dir.name not in skip:
                 dst = skills_dst / skill_dir.name
                 if dst.exists():
                     shutil.rmtree(dst)

--- a/src/yurtle_kanban/config.py
+++ b/src/yurtle_kanban/config.py
@@ -30,18 +30,11 @@ def _load_builtin_theme(theme_name: str, repo_root: Path | None = None) -> dict[
         search_paths.append(repo_root / ".kanban" / "themes" / f"{theme_name}.yaml")
     search_paths.append(Path.cwd() / ".kanban" / "themes" / f"{theme_name}.yaml")
 
-    # Priority 2: Package share directory (pip installed)
-    try:
-        import sys
+    # Priority 2: sys.prefix share directory (pip installed via Hatchling)
+    import sys
 
-        for path in sys.path:
-            share_path = (
-                Path(path).parent / "share" / "yurtle-kanban" / "themes" / f"{theme_name}.yaml"
-            )
-            if share_path.exists():
-                search_paths.append(share_path)
-    except Exception:
-        pass
+    share_path = Path(sys.prefix) / "share" / "yurtle-kanban" / "themes" / f"{theme_name}.yaml"
+    search_paths.append(share_path)
 
     # Priority 3: Source directory (development)
     try:


### PR DESCRIPTION
## Summary

Follow-up to #21 — the `sys.path` parent loop doesn't find `share/yurtle-kanban/` in pip-installed environments because no `sys.path` entry has a parent that is the venv root. Replace with `sys.prefix` which directly points to the venv root per PEP 405.

- **cli.py `_get_shared_data_dir()`**: `sys.path` loop → `sys.prefix` (fixes template/skill resolution)
- **config.py `_load_builtin_theme()`**: same `sys.path` loop → `sys.prefix` (fixes HDD theme loading — the root cause of #20 in production)
- **init command**: dynamic theme-dir detection replaces hardcoded `("nautical", "software")` exclusion

### Why `sys.path` doesn't work

```python
# sys.path entries are all under .venv/lib/python3.11/
# .parent gives .venv/lib/python3.11/ or .venv/lib/ — never .venv/
# But share/ lives at .venv/share/yurtle-kanban/

# sys.prefix directly gives the venv root:
Path(sys.prefix) / "share" / "yurtle-kanban" / subdir  # ← works
```

### Verified

```
nautical: FOUND
software: FOUND
hdd:      FOUND  (was NOT FOUND before this fix)
templates: .venv311/share/yurtle-kanban/templates (exists=True)
skills:    .venv311/share/yurtle-kanban/skills (exists=True)
```

## Test plan

- [x] 276/276 tests pass
- [x] All three themes load in pip-installed venv
- [x] Templates and skills directories resolve correctly
- [ ] After merge: reinstall in nusy venv, verify `hypothesis create` finds template AND routes to `research/hypotheses/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)