### PR TITLE
fix: fail fast if yurtle-rdflib is missing

### DIFF
--- a/src/yurtle_kanban/__init__.py
+++ b/src/yurtle_kanban/__init__.py
@@ -23,12 +23,10 @@ Usage:
 
 __version__ = "1.11.0"
 
-# Register yurtle_rdflib plugin with rdflib (enables format="yurtle" parsing)
-# This must be imported before any rdflib Graph.parse() calls with format="yurtle"
-try:
-    import yurtle_rdflib  # noqa: F401
-except ImportError:
-    pass  # yurtle_rdflib is optional; YAML frontmatter still works without it
+# Register yurtle_rdflib plugin with rdflib (enables format="yurtle" parsing).
+# This must be imported before any rdflib Graph.parse() calls with format="yurtle".
+# Both rdflib and yurtle-rdflib are required dependencies — fail fast if missing.
+import yurtle_rdflib  # noqa: F401
 
 from yurtle_kanban.config import KanbanConfig
 from yurtle_kanban.hooks import HookContext, HookEngine, HookEvent


### PR DESCRIPTION
## Summary

- Removes the silent `try/except` around `import yurtle_rdflib` in `__init__.py`
- If `yurtle-rdflib` (or `rdflib`) is missing, the CLI now fails immediately with an `ImportError` instead of silently producing empty boards

Closes #26

## Test plan

- [x] 322 tests pass
- [ ] Verify that uninstalling `yurtle-rdflib` produces a clear ImportError on `import yurtle_kanban`

🤖 Generated with [Claude Code](https://claude.com/claude-code)