### PR TITLE
feat(EXP-1025): research interlinks in voyage/epic show

### DIFF
--- a/src/yurtle_kanban/research_interlinks.py
+++ b/src/yurtle_kanban/research_interlinks.py
@@ -1,41 +1,29 @@
 """
 Research interlink display for campaign/voyage show.
 
-Parses fenced ```turtle blocks from HDD item files and queries the RDF
-graph for research relationships: hypothesis→paper, experiment→hypothesis,
-measure metadata.
+Queries WorkItem.graph (populated by yurtle-rdflib v0.2.0+ from both
+YAML frontmatter and fenced ```turtle blocks) for HDD research
+relationships: hypothesis→paper, experiment→hypothesis, measure metadata.
 
-Only renders when linked items include HDD types with Turtle knowledge blocks.
+Only renders when linked items include HDD types with knowledge graphs.
 """
 
 from __future__ import annotations
 
-import logging
-import re
-
+from rdflib import Namespace, RDFS
 from rich.console import Console
 from rich.table import Table
 
 from .models import WorkItem, WorkItemStatus, WorkItemType
 from .turtle_builder import PREFIXES
 
-logger = logging.getLogger(__name__)
-
-try:
-    from rdflib import Graph, Namespace, RDFS
-
-    _has_rdflib = True
-except ImportError:
-    _has_rdflib = False
-
-if _has_rdflib:
-    # Derive namespaces from turtle_builder.PREFIXES (single source of truth)
-    HYP = Namespace(PREFIXES["hyp"])
-    PAPER = Namespace(PREFIXES["paper"])
-    EXPR = Namespace(PREFIXES["expr"])
-    MEASURE = Namespace(PREFIXES["measure"])
-    LIT = Namespace(PREFIXES["lit"])
-    IDEA = Namespace(PREFIXES["idea"])
+# Derive namespaces from turtle_builder.PREFIXES (single source of truth)
+HYP = Namespace(PREFIXES["hyp"])
+PAPER = Namespace(PREFIXES["paper"])
+EXPR = Namespace(PREFIXES["expr"])
+MEASURE = Namespace(PREFIXES["measure"])
+LIT = Namespace(PREFIXES["lit"])
+IDEA = Namespace(PREFIXES["idea"])
 
 # HDD item types that carry research metadata
 HDD_TYPES = frozenset({
@@ -56,30 +44,6 @@ _STATUS_COLORS = {
     WorkItemStatus.READY: "blue",
 }
 
-# Regex to extract fenced ```turtle blocks (not ```yurtle status blocks)
-_TURTLE_BLOCK_RE = re.compile(r"```turtle\s*\r?\n(.*?)^```", re.DOTALL | re.MULTILINE)
-
-
-def _parse_turtle_blocks(item: WorkItem) -> Graph:
-    """Parse fenced ```turtle blocks from an item's file into an RDF graph.
-
-    Returns an rdflib Graph with triples from all fenced Turtle blocks.
-    Returns an empty graph if no blocks found or parsing fails.
-    """
-    g = Graph()
-    try:
-        content = item.file_path.read_text()
-    except OSError:
-        return g
-
-    for match in _TURTLE_BLOCK_RE.finditer(content):
-        block = match.group(1)
-        try:
-            g.parse(data=block, format="turtle")
-        except Exception as e:
-            logger.debug(f"Failed to parse turtle block in {item.file_path}: {e}")
-    return g
-
 
 def _obj_id(uri_str: str) -> str:
     """Extract display ID from an RDF URI.
@@ -90,63 +54,56 @@ def _obj_id(uri_str: str) -> str:
     s = str(uri_str)
     if "#" in s:
         return s.rsplit("#", 1)[-1]
-    # For full URIs like https://nusy.dev/paper/PAPER-130
     for prefix_uri in PREFIXES.values():
         if s.startswith(prefix_uri):
             return s[len(prefix_uri):]
     return s.rsplit("/", 1)[-1] if "/" in s else s
 
 
-def _first_value(graph: Graph, predicate) -> str | None:
-    """Get the first object value for a predicate from a graph.
+def _first_triple(item: WorkItem, predicate) -> str | None:
+    """Get the first object value for a predicate from the item's graph.
 
-    Sorts values lexicographically for deterministic results when
-    multiple objects exist for the same predicate.
+    Uses min() for deterministic results — rdflib's graph.triples()
+    iterates over an internal set with no guaranteed order.
     """
-    values = sorted(str(obj) for _, _, obj in graph.triples((None, predicate, None)))
-    return values[0] if values else None
+    values = item.get_knowledge_triples(predicate)
+    return min(values) if values else None
 
 
 def has_research_items(items: list[WorkItem]) -> bool:
-    """Check if any items are HDD types."""
-    return any(item.item_type in HDD_TYPES for item in items)
+    """Check if any items are HDD types with populated graphs."""
+    return any(
+        item.item_type in HDD_TYPES and item.graph is not None
+        for item in items
+    )
 
 
 def render_research_interlinks(items: list[WorkItem], console: Console) -> None:
     """Render research interlinks section for HDD items.
 
-    Parses fenced Turtle blocks from each HDD item's file and displays
-    tables grouped by type. No output if no HDD items exist or rdflib
-    is not installed.
+    Queries each item's RDF graph for research predicates and displays
+    tables grouped by type. No output if no HDD items with graphs exist.
     """
-    if not _has_rdflib:
-        logger.debug("rdflib not available — skipping research interlinks")
-        return
-
-    # Separate HDD items by type, parse their Turtle blocks
-    hypotheses: list[tuple[WorkItem, Graph]] = []
-    experiments: list[tuple[WorkItem, Graph]] = []
-    papers: list[tuple[WorkItem, Graph]] = []
-    measures: list[tuple[WorkItem, Graph]] = []
-    literature: list[tuple[WorkItem, Graph]] = []
+    hypotheses: list[WorkItem] = []
+    experiments: list[WorkItem] = []
+    papers: list[WorkItem] = []
+    measures: list[WorkItem] = []
+    literature: list[WorkItem] = []
 
     for item in items:
-        if item.item_type not in HDD_TYPES:
-            continue
-        g = _parse_turtle_blocks(item)
-        if len(g) == 0:
+        if item.item_type not in HDD_TYPES or item.graph is None:
             continue
         match item.item_type:
             case WorkItemType.HYPOTHESIS:
-                hypotheses.append((item, g))
+                hypotheses.append(item)
             case WorkItemType.EXPERIMENT:
-                experiments.append((item, g))
+                experiments.append(item)
             case WorkItemType.PAPER:
-                papers.append((item, g))
+                papers.append(item)
             case WorkItemType.MEASURE:
-                measures.append((item, g))
+                measures.append(item)
             case WorkItemType.LITERATURE:
-                literature.append((item, g))
+                literature.append(item)
 
     if not any([hypotheses, experiments, papers, measures, literature]):
         return
@@ -157,9 +114,9 @@ def render_research_interlinks(items: list[WorkItem], console: Console) -> None:
     # Papers
     if papers:
         console.print("\n  [bold dim]Papers:[/bold dim]")
-        for p, g in papers:
+        for p in papers:
             color = _STATUS_COLORS.get(p.status, "white")
-            label = _first_value(g, RDFS.label) or p.title
+            label = _first_triple(p, RDFS.label) or p.title
             console.print(
                 f"    [bold]{p.id}[/bold]  {label[:50]}  "
                 f"[{color}]({p.status.value})[/{color}]"
@@ -175,11 +132,11 @@ def render_research_interlinks(items: list[WorkItem], console: Console) -> None:
         table.add_column("Target", width=14)
         table.add_column("Status", width=12)
 
-        for h, g in hypotheses:
-            paper_uri = _first_value(g, HYP.paper)
+        for h in hypotheses:
+            paper_uri = _first_triple(h, HYP.paper)
             paper_display = _obj_id(paper_uri) if paper_uri else "-"
-            target = _first_value(g, HYP.target) or "-"
-            label = _first_value(g, RDFS.label) or h.title
+            target = _first_triple(h, HYP.target) or "-"
+            label = _first_triple(h, RDFS.label) or h.title
             color = _STATUS_COLORS.get(h.status, "white")
             table.add_row(
                 h.id,
@@ -200,12 +157,12 @@ def render_research_interlinks(items: list[WorkItem], console: Console) -> None:
         table.add_column("Paper", width=14)
         table.add_column("Status", width=12)
 
-        for e, g in experiments:
-            hyp_uri = _first_value(g, EXPR.hypothesis)
+        for e in experiments:
+            hyp_uri = _first_triple(e, EXPR.hypothesis)
             hyp_display = _obj_id(hyp_uri) if hyp_uri else "-"
-            paper_uri = _first_value(g, EXPR.paper)
+            paper_uri = _first_triple(e, EXPR.paper)
             paper_display = _obj_id(paper_uri) if paper_uri else "-"
-            label = _first_value(g, RDFS.label) or e.title
+            label = _first_triple(e, RDFS.label) or e.title
             color = _STATUS_COLORS.get(e.status, "white")
             table.add_row(
                 e.id,
@@ -225,20 +182,20 @@ def render_research_interlinks(items: list[WorkItem], console: Console) -> None:
         table.add_column("Unit", width=12)
         table.add_column("Category", width=14)
 
-        for m, g in measures:
-            label = _first_value(g, RDFS.label) or m.title
-            unit = _first_value(g, MEASURE.unit) or "-"
-            category = _first_value(g, MEASURE.category) or "-"
+        for m in measures:
+            label = _first_triple(m, RDFS.label) or m.title
+            unit = _first_triple(m, MEASURE.unit) or "-"
+            category = _first_triple(m, MEASURE.category) or "-"
             table.add_row(m.id, label[:30], unit, category)
         console.print(table)
 
     # Literature
     if literature:
         console.print("\n  [bold dim]Literature:[/bold dim]")
-        for lit, g in literature:
+        for lit in literature:
             color = _STATUS_COLORS.get(lit.status, "white")
-            label = _first_value(g, RDFS.label) or lit.title
-            explores_uri = _first_value(g, LIT.explores)
+            label = _first_triple(lit, RDFS.label) or lit.title
+            explores_uri = _first_triple(lit, LIT.explores)
             explores = f" \u2192 {_obj_id(explores_uri)}" if explores_uri else ""
             console.print(
                 f"    [bold]{lit.id}[/bold]  {label[:40]}{explores}  "

--- a/tests/test_research_interlinks.py
+++ b/tests/test_research_interlinks.py
@@ -14,8 +14,7 @@ from yurtle_kanban.models import WorkItem, WorkItemStatus, WorkItemType
 from yurtle_kanban.research_interlinks import (
     has_research_items,
     render_research_interlinks,
-    _parse_turtle_blocks,
-    _first_value,
+    _first_triple,
     _obj_id,
     HYP,
     EXPR,
@@ -161,6 +160,30 @@ def _write_measure(repo: Path, measure_id: str, title: str, unit: str, category:
     return file_path
 
 
+def _make_item_with_graph(
+    file_path: Path, item_id: str, title: str,
+    item_type: WorkItemType, status: WorkItemStatus,
+) -> WorkItem:
+    """Build a WorkItem with its graph populated via yurtle-rdflib.
+
+    Mirrors what KanbanService._parse_graph() does: reads the file content
+    and parses it with yurtle_rdflib.parse_yurtle() to get the RDF graph
+    (frontmatter + fenced blocks).
+    """
+    import yurtle_rdflib
+
+    content = file_path.read_text()
+    doc = yurtle_rdflib.parse_yurtle(content)
+    return WorkItem(
+        id=item_id,
+        title=title,
+        item_type=item_type,
+        status=status,
+        file_path=file_path,
+        graph=doc.graph,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Unit tests: _obj_id
 # ---------------------------------------------------------------------------
@@ -190,82 +213,76 @@ class TestHasResearchItems:
         ]
         assert has_research_items(items) is False
 
-    def test_hdd_item_detected(self):
+    def test_hdd_item_without_graph(self):
+        """HDD item with no graph should not count as research item."""
         items = [
             WorkItem(id="H130.1", title="T", item_type=WorkItemType.HYPOTHESIS,
                      status=WorkItemStatus.BACKLOG, file_path=Path("/tmp/t.md")),
         ]
-        assert has_research_items(items) is True
+        assert has_research_items(items) is False
+
+    def test_hdd_item_with_graph_detected(self, nautical_repo):
+        """HDD item with a populated graph should be detected."""
+        fp = _write_hypothesis(nautical_repo, "H130.1", "Test", "PAPER-130", ">=85%")
+        item = _make_item_with_graph(fp, "H130.1", "Test", WorkItemType.HYPOTHESIS, WorkItemStatus.BACKLOG)
+        assert has_research_items([item]) is True
 
 
 # ---------------------------------------------------------------------------
-# Unit tests: _parse_turtle_blocks
+# Unit tests: _first_triple (queries WorkItem.graph)
 # ---------------------------------------------------------------------------
 
 
-class TestParseTurtleBlocks:
+class TestFirstTriple:
     def test_hypothesis_paper_triple(self, nautical_repo):
-        """Fenced Turtle block should produce hyp:paper triple."""
+        """Hypothesis item graph should contain hyp:paper triple."""
         fp = _write_hypothesis(nautical_repo, "H130.1", "Test Hyp", "PAPER-130", ">=85%")
-        item = WorkItem(id="H130.1", title="Test Hyp", item_type=WorkItemType.HYPOTHESIS,
-                        status=WorkItemStatus.BACKLOG, file_path=fp)
-        g = _parse_turtle_blocks(item)
-        paper_val = _first_value(g, HYP.paper)
+        item = _make_item_with_graph(fp, "H130.1", "Test Hyp", WorkItemType.HYPOTHESIS, WorkItemStatus.BACKLOG)
+        paper_val = _first_triple(item, HYP.paper)
         assert paper_val is not None
         assert "PAPER-130" in paper_val
 
     def test_hypothesis_target_triple(self, nautical_repo):
-        """Fenced Turtle block should produce hyp:target triple."""
+        """Hypothesis item graph should contain hyp:target triple."""
         fp = _write_hypothesis(nautical_repo, "H130.1", "Test Hyp", "PAPER-130", ">=85%")
-        item = WorkItem(id="H130.1", title="Test Hyp", item_type=WorkItemType.HYPOTHESIS,
-                        status=WorkItemStatus.BACKLOG, file_path=fp)
-        g = _parse_turtle_blocks(item)
-        assert _first_value(g, HYP.target) == ">=85%"
+        item = _make_item_with_graph(fp, "H130.1", "Test Hyp", WorkItemType.HYPOTHESIS, WorkItemStatus.BACKLOG)
+        assert _first_triple(item, HYP.target) == ">=85%"
 
     def test_experiment_hypothesis_triple(self, nautical_repo):
-        """Fenced Turtle block should produce expr:hypothesis triple."""
+        """Experiment item graph should contain expr:hypothesis triple."""
         fp = _write_experiment(nautical_repo, "EXPR-130", "Test Exp", "PAPER-130", "H130.1")
-        item = WorkItem(id="EXPR-130", title="Test Exp", item_type=WorkItemType.EXPERIMENT,
-                        status=WorkItemStatus.IN_PROGRESS, file_path=fp)
-        g = _parse_turtle_blocks(item)
-        hyp_val = _first_value(g, EXPR.hypothesis)
+        item = _make_item_with_graph(fp, "EXPR-130", "Test Exp", WorkItemType.EXPERIMENT, WorkItemStatus.IN_PROGRESS)
+        hyp_val = _first_triple(item, EXPR.hypothesis)
         assert hyp_val is not None
         assert "H130.1" in hyp_val
 
     def test_experiment_paper_triple(self, nautical_repo):
-        """Fenced Turtle block should produce expr:paper triple."""
+        """Experiment item graph should contain expr:paper triple."""
         fp = _write_experiment(nautical_repo, "EXPR-130", "Test Exp", "PAPER-130", "H130.1")
-        item = WorkItem(id="EXPR-130", title="Test Exp", item_type=WorkItemType.EXPERIMENT,
-                        status=WorkItemStatus.IN_PROGRESS, file_path=fp)
-        g = _parse_turtle_blocks(item)
-        paper_val = _first_value(g, EXPR.paper)
+        item = _make_item_with_graph(fp, "EXPR-130", "Test Exp", WorkItemType.EXPERIMENT, WorkItemStatus.IN_PROGRESS)
+        paper_val = _first_triple(item, EXPR.paper)
         assert paper_val is not None
         assert "PAPER-130" in paper_val
 
     def test_measure_unit_category(self, nautical_repo):
-        """Fenced Turtle block should produce measure:unit and measure:category triples."""
+        """Measure item graph should contain measure:unit and measure:category triples."""
         fp = _write_measure(nautical_repo, "M-001", "Accuracy", "percent", "accuracy")
-        item = WorkItem(id="M-001", title="Accuracy", item_type=WorkItemType.MEASURE,
-                        status=WorkItemStatus.DONE, file_path=fp)
-        g = _parse_turtle_blocks(item)
-        assert _first_value(g, MEASURE.unit) == "percent"
-        assert _first_value(g, MEASURE.category) == "accuracy"
+        item = _make_item_with_graph(fp, "M-001", "Accuracy", WorkItemType.MEASURE, WorkItemStatus.DONE)
+        assert _first_triple(item, MEASURE.unit) == "percent"
+        assert _first_triple(item, MEASURE.category) == "accuracy"
 
-    def test_no_turtle_block_returns_empty_graph(self, tmp_path):
-        """File without Turtle block should return empty graph."""
+    def test_no_turtle_block_returns_none(self, tmp_path):
+        """Item without Turtle block should return None for HDD predicates."""
         fp = tmp_path / "test.md"
         fp.write_text("---\nid: EXP-001\ntitle: Test\ntype: expedition\nstatus: backlog\n---\n\n# Test\n")
-        item = WorkItem(id="EXP-001", title="Test", item_type=WorkItemType.EXPEDITION,
-                        status=WorkItemStatus.BACKLOG, file_path=fp)
-        g = _parse_turtle_blocks(item)
-        assert len(g) == 0
+        item = _make_item_with_graph(fp, "EXP-001", "Test", WorkItemType.EXPEDITION, WorkItemStatus.BACKLOG)
+        assert _first_triple(item, HYP.paper) is None
 
-    def test_missing_file_returns_empty_graph(self):
-        """Non-existent file should return empty graph."""
+    def test_no_graph_returns_none(self):
+        """Item with no graph should return None."""
         item = WorkItem(id="X-999", title="T", item_type=WorkItemType.HYPOTHESIS,
                         status=WorkItemStatus.BACKLOG, file_path=Path("/nonexistent/file.md"))
-        g = _parse_turtle_blocks(item)
-        assert len(g) == 0
+        assert _first_triple(item, HYP.paper) is None
 
 
 # ---------------------------------------------------------------------------
@@ -288,8 +305,7 @@ class TestRender:
     def test_hypothesis_renders_table(self, nautical_repo):
         """Hypothesis with Turtle block should render Research Interlinks section."""
         fp = _write_hypothesis(nautical_repo, "H130.1", "Test Hyp", "PAPER-130", ">=85%")
-        item = WorkItem(id="H130.1", title="Test Hyp", item_type=WorkItemType.HYPOTHESIS,
-                        status=WorkItemStatus.BACKLOG, file_path=fp)
+        item = _make_item_with_graph(fp, "H130.1", "Test Hyp", WorkItemType.HYPOTHESIS, WorkItemStatus.BACKLOG)
 
         buf = StringIO()
         console = Console(file=buf, force_terminal=True, width=120)
@@ -303,8 +319,7 @@ class TestRender:
     def test_experiment_renders_table(self, nautical_repo):
         """Experiment with Turtle block should render experiment table."""
         fp = _write_experiment(nautical_repo, "EXPR-130", "Signal Fusion", "PAPER-130", "H130.1")
-        item = WorkItem(id="EXPR-130", title="Signal Fusion", item_type=WorkItemType.EXPERIMENT,
-                        status=WorkItemStatus.IN_PROGRESS, file_path=fp)
+        item = _make_item_with_graph(fp, "EXPR-130", "Signal Fusion", WorkItemType.EXPERIMENT, WorkItemStatus.IN_PROGRESS)
 
         buf = StringIO()
         console = Console(file=buf, force_terminal=True, width=120)
@@ -317,8 +332,7 @@ class TestRender:
     def test_measure_renders_table(self, nautical_repo):
         """Measure with Turtle block should render measure table."""
         fp = _write_measure(nautical_repo, "M-001", "Accuracy", "percent", "accuracy")
-        item = WorkItem(id="M-001", title="Accuracy", item_type=WorkItemType.MEASURE,
-                        status=WorkItemStatus.DONE, file_path=fp)
+        item = _make_item_with_graph(fp, "M-001", "Accuracy", WorkItemType.MEASURE, WorkItemStatus.DONE)
 
         buf = StringIO()
         console = Console(file=buf, force_terminal=True, width=120)


### PR DESCRIPTION
## Summary

- Adds **Research Interlinks** section to `voyage show` / `epic show` for HDD items
- Queries `WorkItem.graph` (populated by yurtle-rdflib v0.2.0) for research predicates (`hyp:paper`, `hyp:target`, `expr:hypothesis`, `measure:unit`, etc.)
- Groups linked items by type (Papers, Hypotheses, Experiments, Measures, Literature) with Rich tables
- Only renders when linked items include HDD types with populated knowledge graphs

## Changes

| File | Action |
|------|--------|
| `src/yurtle_kanban/research_interlinks.py` | **New** — graph query + Rich rendering |
| `src/yurtle_kanban/epic_commands.py` | **Modified** — 4 lines wiring interlinks into `_do_show()` |
| `tests/test_research_interlinks.py` | **New** — 20 tests (unit + integration) |

## Test plan

- [x] 20 new tests pass (unit: _obj_id, has_research_items, _first_triple, render; integration: voyage show)
- [x] Full suite: 349/349 pass
- [ ] Manual test: `yurtle-kanban voyage show VOY-108` in nusy repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)