### PR TITLE
feat: experiment run tracking + HDD registry & validation (EXP-1001 P3-4)

### DIFF
--- a/src/yurtle_kanban/hdd_commands.py
+++ b/src/yurtle_kanban/hdd_commands.py
@@ -109,6 +109,222 @@ def hdd_backfill(dry_run):
     console.print("  ".join(summary_parts))
 
 
+@hdd.command("registry")
+@click.option("--output", "output_path", default=None, help="Output file path (default: research/REGISTRY.md)")
+@click.option("--push", is_flag=True, help="Commit and push the registry file")
+def hdd_registry(output_path: str | None, push: bool):
+    """Auto-generate a research registry from all HDD items.
+
+    Scans papers, hypotheses, experiments, measures, ideas, and literature,
+    then writes a cross-referenced REGISTRY.md file.
+
+    Examples:
+        yurtle-kanban hdd registry
+        yurtle-kanban hdd registry --output research/REGISTRY.md --push
+    """
+    import subprocess
+
+    service = _get_service()
+    xrefs = service.get_hdd_cross_references()
+
+    lines = [
+        "# HDD Research Registry",
+        "*Auto-generated — do not edit manually*",
+        "",
+    ]
+
+    # Papers section
+    papers = xrefs["papers"]
+    lines.append(f"## Papers ({len(papers)} total)")
+    if papers:
+        lines.append("")
+        lines.append("| ID | Title | Status | Hypotheses |")
+        lines.append("|----|-------|--------|------------|")
+        for p in papers:
+            hyps = ", ".join(p["hypotheses"]) or "—"
+            lines.append(f"| {p['id']} | {p['title']} | {p['status']} | {hyps} |")
+    else:
+        lines.append("No papers found.")
+    lines.append("")
+
+    # Hypotheses section
+    hypotheses = xrefs["hypotheses"]
+    lines.append(f"## Hypotheses ({len(hypotheses)} total)")
+    if hypotheses:
+        lines.append("")
+        lines.append("| ID | Paper | Statement | Target | Status | Experiments |")
+        lines.append("|----|-------|-----------|--------|--------|-------------|")
+        for h in hypotheses:
+            exps = ", ".join(h["experiments"]) or "—"
+            target = h.get("target", "") or "—"
+            lines.append(
+                f"| {h['id']} | {h['paper']} | {h['title']} | {target} | {h['status']} | {exps} |"
+            )
+    else:
+        lines.append("No hypotheses found.")
+    lines.append("")
+
+    # Experiments section
+    experiments = xrefs["experiments"]
+    lines.append(f"## Experiments ({len(experiments)} total)")
+    if experiments:
+        lines.append("")
+        lines.append("| ID | Hypothesis | Status | Runs | Last Outcome |")
+        lines.append("|----|------------|--------|------|--------------|")
+        for e in experiments:
+            lines.append(
+                f"| {e['id']} | {e['hypothesis']} | {e['status']} | {e['runs']} | {e['last_outcome'] or '—'} |"
+            )
+    else:
+        lines.append("No experiments found.")
+    lines.append("")
+
+    # Measures section
+    measures = xrefs["measures"]
+    lines.append(f"## Measures ({len(measures)} total)")
+    if measures:
+        lines.append("")
+        lines.append("| ID | Name | Unit | Category |")
+        lines.append("|----|------|------|----------|")
+        for m in measures:
+            lines.append(f"| {m['id']} | {m['title']} | {m['unit']} | {m['category']} |")
+    else:
+        lines.append("No measures found.")
+    lines.append("")
+
+    # Orphaned section
+    orphaned = xrefs["orphaned"]
+    if orphaned:
+        lines.append(f"## Orphaned Items ({len(orphaned)})")
+        lines.append("")
+        for o in orphaned:
+            lines.append(f"- {o['id']}: {o['reason']}")
+        lines.append("")
+
+    # Write registry file
+    from pathlib import Path
+
+    if output_path:
+        out = Path(output_path)
+    else:
+        out = service.repo_root / "research" / "REGISTRY.md"
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text("\n".join(lines))
+
+    console.print(f"[green]Registry written to {out}[/green]")
+
+    total = (
+        len(papers) + len(hypotheses) + len(experiments)
+        + len(measures) + len(xrefs["ideas"]) + len(xrefs["literature"])
+    )
+    console.print(f"  {total} items indexed, {len(orphaned)} orphaned")
+
+    if push:
+        try:
+            subprocess.run(
+                ["git", "add", str(out)],
+                cwd=str(service.repo_root),
+                capture_output=True,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "commit", "-m", "hdd: update research registry"],
+                cwd=str(service.repo_root),
+                capture_output=True,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "push"],
+                cwd=str(service.repo_root),
+                capture_output=True,
+                check=True,
+            )
+            console.print("  [dim]Committed and pushed[/dim]")
+        except subprocess.CalledProcessError as e:
+            console.print(f"  [yellow]Warning: git push failed: {e}[/yellow]")
+
+
+@hdd.command("validate")
+@click.option("--strict", is_flag=True, help="Treat warnings as errors (exit 1)")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+def hdd_validate(strict: bool, as_json: bool):
+    """Validate bidirectional links between HDD research items.
+
+    Checks that hypotheses reference papers, experiments reference hypotheses,
+    and all cross-references point to existing items.
+
+    Examples:
+        yurtle-kanban hdd validate
+        yurtle-kanban hdd validate --strict
+        yurtle-kanban hdd validate --json
+    """
+    import json as json_mod
+    import sys
+
+    service = _get_service()
+    report = service.validate_hdd_links()
+
+    if as_json:
+        click.echo(json_mod.dumps(report, indent=2, default=str))
+        if report["errors"] or (strict and report["warnings"]):
+            sys.exit(1)
+        return
+
+    console.print("[bold]HDD Validation Report[/bold]")
+    console.print("=" * 40)
+    console.print()
+
+    s = report["summary"]
+
+    # Papers
+    paper_ok = s["papers"] > 0
+    mark = "[green]OK[/green]" if paper_ok else "[dim]—[/dim]"
+    console.print(f"  {mark} {s['papers']} papers")
+
+    # Hypotheses
+    hyp_warns = [w for w in report["warnings"] if "hypothesis" in w.get("issue", "")]
+    hyp_errs = [e for e in report["errors"] if e["id"].startswith("H")]
+    if not hyp_warns and not hyp_errs:
+        console.print(f"  [green]OK[/green] {s['hypotheses']} hypotheses — all linked to papers")
+    else:
+        console.print(f"  [yellow]!![/yellow] {s['hypotheses']} hypotheses")
+        for w in hyp_warns:
+            console.print(f"    [yellow]Warning:[/yellow] {w['id']}: {w['issue']}")
+        for e in hyp_errs:
+            console.print(f"    [red]Error:[/red] {e['id']}: {e['issue']}")
+
+    # Experiments
+    exp_warns = [w for w in report["warnings"] if "experiment" in w.get("issue", "")]
+    exp_errs = [e for e in report["errors"] if e["id"].startswith("EXPR")]
+    if not exp_warns and not exp_errs:
+        console.print(f"  [green]OK[/green] {s['experiments']} experiments — all linked to hypotheses")
+    else:
+        console.print(f"  [yellow]!![/yellow] {s['experiments']} experiments")
+        for w in exp_warns:
+            console.print(f"    [yellow]Warning:[/yellow] {w['id']}: {w['issue']}")
+        for e in exp_errs:
+            console.print(f"    [red]Error:[/red] {e['id']}: {e['issue']}")
+
+    # Measures
+    measure_warns = [w for w in report["warnings"] if "measure" in w.get("issue", "")]
+    if not measure_warns:
+        console.print(f"  [green]OK[/green] {s['measures']} measures — all referenced")
+    else:
+        referenced = s["measures"] - len(measure_warns)
+        console.print(f"  [yellow]!![/yellow] {s['measures']} measures — {referenced} referenced, {len(measure_warns)} unused")
+        for w in measure_warns:
+            console.print(f"    [yellow]Warning:[/yellow] {w['id']}: {w['issue']}")
+
+    console.print()
+    console.print(
+        f"  Summary: {s['errors']} errors, {s['warnings']} warnings"
+    )
+
+    if report["errors"] or (strict and report["warnings"]):
+        sys.exit(1)
+
+
 # ---------------------------------------------------------------------------
 # idea
 # ---------------------------------------------------------------------------
@@ -528,6 +744,139 @@ def experiment_create(
         console.print(f"[green]Created {item.id}: {title}[/green]")
         console.print(f"  File: {item.file_path}")
         _update_parent(service, hyp_id, "experiment", item.id, push=False)
+
+
+@experiment.command("run")
+@click.argument("expr_id")
+@click.option("--being", required=True, help="Being name/version (e.g., santiago-toddler-v12.4)")
+@click.option("--params", "params_str", default=None, help="Comma-separated key=value pairs (e.g., 'kbdd_rounds=3,wikidata=true')")
+@click.option("--run-by", default=None, help="Who started the run (default: git user.name)")
+@click.option("--push", is_flag=True, help="Atomic: commit and push the config.yaml")
+def experiment_run(expr_id: str, being: str, params_str: str | None, run_by: str | None, push: bool):
+    """Create a new experiment run with a timestamped folder.
+
+    Creates research/runs/EXPR-ID/TIMESTAMP/config.yaml with run metadata.
+    Scripts and training can write metrics.json to the returned folder.
+
+    Examples:
+        yurtle-kanban experiment run EXPR-130 --being santiago-toddler-v12.4
+        yurtle-kanban experiment run EXPR-130 --being v12.4 --params "kbdd_rounds=3,wikidata=true"
+    """
+    service = _get_service()
+
+    # Normalize ID
+    if not expr_id.startswith("EXPR-"):
+        expr_id = f"EXPR-{expr_id}"
+
+    # Parse params
+    params: dict[str, str] | None = None
+    if params_str:
+        params = {}
+        for pair in params_str.split(","):
+            pair = pair.strip()
+            if "=" in pair:
+                k, v = pair.split("=", 1)
+                params[k.strip()] = v.strip()
+
+    run_path = service.create_experiment_run(
+        expr_id=expr_id,
+        being=being,
+        params=params,
+        run_by=run_by,
+    )
+
+    console.print(f"[green]Created run for {expr_id}[/green]")
+    console.print(f"  Path: {run_path}")
+
+    if push:
+        import subprocess
+
+        try:
+            config_path = run_path / "config.yaml"
+            subprocess.run(
+                ["git", "add", str(config_path)],
+                cwd=str(service.repo_root),
+                capture_output=True,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "commit", "-m", f"experiment run: {expr_id} ({run_path.name})"],
+                cwd=str(service.repo_root),
+                capture_output=True,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "push"],
+                cwd=str(service.repo_root),
+                capture_output=True,
+                check=True,
+            )
+            console.print("  [dim]Committed and pushed[/dim]")
+        except subprocess.CalledProcessError as e:
+            console.print(f"  [yellow]Warning: git push failed: {e}[/yellow]")
+
+
+@experiment.command("status")
+@click.argument("expr_id")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON for scripting")
+def experiment_status(expr_id: str, as_json: bool):
+    """Show all runs for an experiment.
+
+    Displays a table of runs with being, status, and outcome.
+
+    Examples:
+        yurtle-kanban experiment status EXPR-130
+        yurtle-kanban experiment status EXPR-130 --json
+    """
+    import json as json_mod
+
+    service = _get_service()
+
+    # Normalize ID
+    if not expr_id.startswith("EXPR-"):
+        expr_id = f"EXPR-{expr_id}"
+
+    runs = service.get_experiment_runs(expr_id)
+
+    if as_json:
+        # Serialize Path objects to strings
+        for r in runs:
+            r["run_path"] = str(r["run_path"])
+        click.echo(json_mod.dumps(runs, indent=2, default=str))
+        return
+
+    # Look up experiment title
+    item = service.get_item(expr_id)
+    title = item.title if item else expr_id
+
+    if not runs:
+        console.print(f"[dim]{expr_id}: {title}[/dim]")
+        console.print("  No runs found.")
+        return
+
+    from rich.table import Table
+
+    table = Table(title=f"{expr_id}: {title}")
+    table.add_column("Run", width=22)
+    table.add_column("Being", width=28)
+    table.add_column("Status", width=12)
+    table.add_column("Outcome")
+
+    for run in runs:
+        outcome = run.get("outcome", run.get("summary", ""))
+        status_style = {
+            "running": "yellow",
+            "complete": "green",
+            "failed": "red",
+        }.get(run["status"], "dim")
+        table.add_row(
+            run["timestamp"][:19],
+            run["being"],
+            f"[{status_style}]{run['status']}[/{status_style}]",
+            outcome or "",
+        )
+
+    console.print(table)
 
 
 # ---------------------------------------------------------------------------

--- a/src/yurtle_kanban/service.py
+++ b/src/yurtle_kanban/service.py
@@ -2413,3 +2413,388 @@ class KanbanService:
         # unranked already sorted by priority_score from get_items()
 
         return ranked + unranked
+
+    # ------------------------------------------------------------------
+    # Experiment run tracking (Phase 3)
+    # ------------------------------------------------------------------
+
+    def create_experiment_run(
+        self,
+        expr_id: str,
+        being: str,
+        params: dict[str, str] | None = None,
+        run_by: str | None = None,
+    ) -> Path:
+        """Create a timestamped experiment run folder with config.yaml.
+
+        Args:
+            expr_id: Experiment ID (e.g., EXPR-130)
+            being: Being name/version (e.g., santiago-toddler-v12.4)
+            params: Optional key=value parameters
+            run_by: Who started the run (default: git user.name)
+
+        Returns:
+            Path to the created run folder.
+        """
+        # Resolve run_by from git config if not provided
+        if run_by is None:
+            try:
+                result = subprocess.run(
+                    ["git", "config", "user.name"],
+                    cwd=self.repo_root,
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                )
+                run_by = result.stdout.strip() or "unknown"
+            except subprocess.CalledProcessError:
+                run_by = "unknown"
+
+        # Look up the experiment to get hypothesis link
+        item = self.get_item(expr_id)
+        hypothesis = ""
+        if item and item.file_path and item.file_path.exists():
+            content = item.file_path.read_text()
+            fm = self._parse_frontmatter(content)
+            hypothesis = fm.get("hypothesis", "")
+
+        # Create timestamped folder (microseconds to avoid collisions)
+        now = datetime.now()
+        timestamp = now.strftime("%Y-%m-%dT%H%M%S") + f"-{now.microsecond:06d}"
+        runs_dir = self.repo_root / "research" / "runs" / expr_id / timestamp
+        runs_dir.mkdir(parents=True, exist_ok=True)
+
+        # Write config.yaml
+        config_data: dict[str, Any] = {
+            "experiment": expr_id,
+            "hypothesis": hypothesis,
+            "being": being,
+            "created": now.isoformat(timespec="seconds"),
+            "run_by": run_by,
+            "status": "running",
+        }
+        if params:
+            config_data["params"] = params
+
+        config_path = runs_dir / "config.yaml"
+        config_path.write_text(yaml.dump(config_data, default_flow_style=False, sort_keys=False))
+
+        return runs_dir
+
+    def get_experiment_runs(self, expr_id: str) -> list[dict[str, Any]]:
+        """Get all runs for an experiment, sorted by date descending.
+
+        Args:
+            expr_id: Experiment ID (e.g., EXPR-130)
+
+        Returns:
+            List of run metadata dicts with keys: timestamp, being, status,
+            outcome, run_by, params, run_path.
+        """
+        runs_base = self.repo_root / "research" / "runs" / expr_id
+        if not runs_base.exists():
+            return []
+
+        runs = []
+        for run_dir in sorted(runs_base.iterdir(), reverse=True):
+            if not run_dir.is_dir():
+                continue
+            config_path = run_dir / "config.yaml"
+            if not config_path.exists():
+                continue
+
+            try:
+                config_data = yaml.safe_load(config_path.read_text()) or {}
+            except yaml.YAMLError:
+                continue
+
+            run_info: dict[str, Any] = {
+                "timestamp": config_data.get("created", run_dir.name),
+                "being": config_data.get("being", ""),
+                "status": config_data.get("status", "unknown"),
+                "run_by": config_data.get("run_by", ""),
+                "params": config_data.get("params", {}),
+                "run_path": run_dir,
+            }
+
+            # Check for metrics.json
+            metrics_path = run_dir / "metrics.json"
+            if metrics_path.exists():
+                import json
+
+                try:
+                    metrics = json.loads(metrics_path.read_text())
+                    run_info["outcome"] = metrics.get("outcome", "")
+                    run_info["summary"] = metrics.get("summary", "")
+                except (json.JSONDecodeError, OSError):
+                    pass
+
+            runs.append(run_info)
+
+        return runs
+
+    def update_run_status(
+        self,
+        run_path: Path,
+        status: str,
+        outcome: str | None = None,
+    ) -> None:
+        """Update the status (and optionally outcome) of an experiment run.
+
+        Args:
+            run_path: Path to the run folder
+            status: New status (e.g., "running", "complete", "failed")
+            outcome: Optional outcome string (e.g., "VALIDATED", "REFUTED")
+        """
+        config_path = run_path / "config.yaml"
+        if not config_path.exists():
+            raise FileNotFoundError(f"No config.yaml in {run_path}")
+
+        config_data = yaml.safe_load(config_path.read_text()) or {}
+        config_data["status"] = status
+        if outcome is not None:
+            config_data["outcome"] = outcome
+
+        config_path.write_text(
+            yaml.dump(config_data, default_flow_style=False, sort_keys=False)
+        )
+
+    # ------------------------------------------------------------------
+    # HDD Registry & Validation (Phase 4)
+    # ------------------------------------------------------------------
+
+    def _get_hdd_frontmatter(self, item: WorkItem) -> dict[str, Any]:
+        """Read raw frontmatter for an HDD item (includes paper, hypothesis, etc.)."""
+        if not item.file_path or not item.file_path.exists():
+            return {}
+        content = item.file_path.read_text()
+        return self._parse_frontmatter(content) or {}
+
+    def get_hdd_cross_references(self) -> dict[str, Any]:
+        """Build a full cross-reference map of all HDD items.
+
+        Returns a dict with keys: papers, hypotheses, experiments, measures,
+        ideas, literature, orphaned. Each value is a list of dicts.
+        """
+        hdd_types = {
+            WorkItemType.PAPER, WorkItemType.HYPOTHESIS, WorkItemType.EXPERIMENT,
+            WorkItemType.MEASURE, WorkItemType.IDEA, WorkItemType.LITERATURE,
+        }
+        all_items = self.get_items()
+        hdd_items = [i for i in all_items if i.item_type in hdd_types]
+
+        # Group by type
+        by_type: dict[str, list[WorkItem]] = {
+            "paper": [], "hypothesis": [], "experiment": [],
+            "measure": [], "idea": [], "literature": [],
+        }
+        for item in hdd_items:
+            type_key = item.item_type.value
+            if type_key in by_type:
+                by_type[type_key].append(item)
+
+        # Build cross-reference maps
+        # Paper → hypotheses
+        paper_hyps: dict[str, list[str]] = {}
+        # Hypothesis → experiments
+        hyp_exps: dict[str, list[str]] = {}
+        # Hypothesis → paper
+        hyp_paper: dict[str, str] = {}
+        # Experiment → hypothesis
+        exp_hyp: dict[str, str] = {}
+        # Idea → literature
+        idea_lits: dict[str, list[str]] = {}
+        # Literature → idea
+        lit_idea: dict[str, str] = {}
+
+        for item in by_type["hypothesis"]:
+            fm = self._get_hdd_frontmatter(item)
+            paper_ref = fm.get("paper", "")
+            if paper_ref:
+                paper_id = str(paper_ref)
+                if not paper_id.startswith("PAPER-"):
+                    paper_id = f"PAPER-{paper_id}"
+                hyp_paper[item.id] = paper_id
+                paper_hyps.setdefault(paper_id, []).append(item.id)
+
+        for item in by_type["experiment"]:
+            fm = self._get_hdd_frontmatter(item)
+            hyp_ref = fm.get("hypothesis", "")
+            if hyp_ref:
+                exp_hyp[item.id] = str(hyp_ref)
+                hyp_exps.setdefault(str(hyp_ref), []).append(item.id)
+
+        for item in by_type["literature"]:
+            fm = self._get_hdd_frontmatter(item)
+            idea_ref = fm.get("source_idea", "") or fm.get("idea", "")
+            if idea_ref:
+                lit_idea[item.id] = str(idea_ref)
+                idea_lits.setdefault(str(idea_ref), []).append(item.id)
+
+        # Build result
+        result: dict[str, Any] = {
+            "papers": [],
+            "hypotheses": [],
+            "experiments": [],
+            "measures": [],
+            "ideas": [],
+            "literature": [],
+            "orphaned": [],
+        }
+
+        for p in by_type["paper"]:
+            result["papers"].append({
+                "id": p.id, "title": p.title, "status": p.status.value,
+                "hypotheses": paper_hyps.get(p.id, []),
+            })
+
+        for h in by_type["hypothesis"]:
+            fm = self._get_hdd_frontmatter(h)
+            result["hypotheses"].append({
+                "id": h.id, "title": h.title, "status": h.status.value,
+                "paper": hyp_paper.get(h.id, ""),
+                "target": fm.get("target", ""),
+                "experiments": hyp_exps.get(h.id, []),
+            })
+
+        for e in by_type["experiment"]:
+            runs = self.get_experiment_runs(e.id)
+            last_outcome = ""
+            if runs:
+                last_outcome = runs[0].get("outcome", runs[0].get("summary", ""))
+            result["experiments"].append({
+                "id": e.id, "title": e.title, "status": e.status.value,
+                "hypothesis": exp_hyp.get(e.id, ""),
+                "runs": len(runs),
+                "last_outcome": last_outcome,
+            })
+
+        for m in by_type["measure"]:
+            fm = self._get_hdd_frontmatter(m)
+            result["measures"].append({
+                "id": m.id, "title": m.title,
+                "unit": fm.get("unit", ""),
+                "category": fm.get("category", ""),
+            })
+
+        for idea_item in by_type["idea"]:
+            result["ideas"].append({
+                "id": idea_item.id, "title": idea_item.title,
+                "status": idea_item.status.value,
+                "literature": idea_lits.get(idea_item.id, []),
+            })
+
+        for lit in by_type["literature"]:
+            result["literature"].append({
+                "id": lit.id, "title": lit.title, "status": lit.status.value,
+                "idea": lit_idea.get(lit.id, ""),
+            })
+
+        # Orphaned items: hypotheses without paper, experiments without hypothesis
+        for h in by_type["hypothesis"]:
+            paper = hyp_paper.get(h.id, "")
+            if not paper and not h.id.startswith("H-DRAFT"):
+                result["orphaned"].append({
+                    "id": h.id, "reason": "No paper assignment",
+                })
+        for e in by_type["experiment"]:
+            hyp = exp_hyp.get(e.id, "")
+            if not hyp:
+                result["orphaned"].append({
+                    "id": e.id, "reason": "No hypothesis link",
+                })
+
+        return result
+
+    def validate_hdd_links(self) -> dict[str, Any]:
+        """Validate bidirectional links between HDD items.
+
+        Returns a validation report dict with keys: errors, warnings, summary.
+        """
+        xrefs = self.get_hdd_cross_references()
+
+        # Collect all known IDs
+        all_ids: set[str] = set()
+        for section in ("papers", "hypotheses", "experiments", "measures", "ideas", "literature"):
+            for item in xrefs[section]:
+                all_ids.add(item["id"])
+
+        errors: list[dict[str, str]] = []
+        warnings: list[dict[str, str]] = []
+
+        # Check hypotheses → paper links
+        for h in xrefs["hypotheses"]:
+            paper = h.get("paper", "")
+            if not paper:
+                if not h["id"].startswith("H-DRAFT"):
+                    warnings.append({
+                        "id": h["id"],
+                        "issue": "hypothesis missing paper link",
+                    })
+            elif paper not in all_ids:
+                errors.append({
+                    "id": h["id"],
+                    "issue": f"references {paper} (not found)",
+                })
+
+        # Check experiments → hypothesis links
+        for e in xrefs["experiments"]:
+            hyp = e.get("hypothesis", "")
+            if not hyp:
+                warnings.append({
+                    "id": e["id"],
+                    "issue": "experiment missing hypothesis link",
+                })
+            elif hyp not in all_ids:
+                errors.append({
+                    "id": e["id"],
+                    "issue": f"references {hyp} (not found)",
+                })
+
+        # Check literature → idea links (warning, not error)
+        for lit in xrefs["literature"]:
+            idea = lit.get("idea", "")
+            if idea and idea not in all_ids:
+                warnings.append({
+                    "id": lit["id"],
+                    "issue": f"references {idea} (not found)",
+                })
+
+        # Check for unused measures
+        used_measures: set[str] = set()
+        for h in xrefs["hypotheses"]:
+            item = self.get_item(h["id"])
+            if item and item.graph:
+                for triple_obj in item.get_knowledge_triples(_HYP.measuredBy):
+                    # Extract measure ID from URI
+                    obj_str = str(triple_obj)
+                    if "/" in obj_str:
+                        used_measures.add(obj_str.split("/")[-1])
+                    else:
+                        used_measures.add(obj_str)
+
+        for m in xrefs["measures"]:
+            if m["id"] not in used_measures:
+                warnings.append({
+                    "id": m["id"],
+                    "issue": "measure not referenced by any hypothesis",
+                })
+
+        summary = {
+            "papers": len(xrefs["papers"]),
+            "hypotheses": len(xrefs["hypotheses"]),
+            "experiments": len(xrefs["experiments"]),
+            "measures": len(xrefs["measures"]),
+            "ideas": len(xrefs["ideas"]),
+            "literature": len(xrefs["literature"]),
+            "errors": len(errors),
+            "warnings": len(warnings),
+            "orphaned": len(xrefs["orphaned"]),
+        }
+
+        return {
+            "errors": errors,
+            "warnings": warnings,
+            "orphaned": xrefs["orphaned"],
+            "summary": summary,
+        }

--- a/tests/test_hdd_commands.py
+++ b/tests/test_hdd_commands.py
@@ -919,3 +919,630 @@ class TestParentAutoUpdate:
         hyp_dir = temp_repo / "research" / "hypotheses"
         files = list(hyp_dir.glob("H999.1*.md"))
         assert len(files) == 1
+
+
+# ---------------------------------------------------------------------------
+# TestExperimentRun
+# ---------------------------------------------------------------------------
+
+
+class TestExperimentRun:
+    """Tests for 'yurtle-kanban experiment run'."""
+
+    def test_experiment_run_creates_folder(self, runner, temp_repo, hdd_config):
+        """experiment run should create a timestamped folder with config.yaml."""
+        result = runner.invoke(
+            main,
+            ["experiment", "run", "EXPR-130", "--being", "santiago-toddler-v12.4"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        assert "Created run for EXPR-130" in result.output
+
+        # Verify folder structure
+        runs_dir = temp_repo / "research" / "runs" / "EXPR-130"
+        assert runs_dir.exists()
+        run_folders = list(runs_dir.iterdir())
+        assert len(run_folders) == 1
+        config_path = run_folders[0] / "config.yaml"
+        assert config_path.exists()
+
+    def test_experiment_run_config_contents(self, runner, temp_repo, hdd_config):
+        """config.yaml should contain experiment, being, and status fields."""
+        runner.invoke(
+            main,
+            ["experiment", "run", "EXPR-130", "--being", "test-being-v12"],
+            catch_exceptions=False,
+        )
+
+        runs_dir = temp_repo / "research" / "runs" / "EXPR-130"
+        run_folders = list(runs_dir.iterdir())
+        config_path = run_folders[0] / "config.yaml"
+        config = yaml.safe_load(config_path.read_text())
+
+        assert config["experiment"] == "EXPR-130"
+        assert config["being"] == "test-being-v12"
+        assert config["status"] == "running"
+        assert "created" in config
+
+    def test_experiment_run_with_params(self, runner, temp_repo, hdd_config):
+        """--params should be parsed into config.yaml params dict."""
+        runner.invoke(
+            main,
+            [
+                "experiment", "run", "EXPR-130",
+                "--being", "test-being",
+                "--params", "kbdd_rounds=3,wikidata=true",
+            ],
+            catch_exceptions=False,
+        )
+
+        runs_dir = temp_repo / "research" / "runs" / "EXPR-130"
+        run_folders = list(runs_dir.iterdir())
+        config = yaml.safe_load((run_folders[0] / "config.yaml").read_text())
+
+        assert config["params"]["kbdd_rounds"] == "3"
+        assert config["params"]["wikidata"] == "true"
+
+    def test_experiment_run_auto_prefixes(self, runner, temp_repo, hdd_config):
+        """ID without EXPR- prefix should be normalized."""
+        result = runner.invoke(
+            main,
+            ["experiment", "run", "130", "--being", "test-being"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert "EXPR-130" in result.output
+
+    def test_experiment_run_with_run_by(self, runner, temp_repo, hdd_config):
+        """--run-by should be stored in config.yaml."""
+        runner.invoke(
+            main,
+            [
+                "experiment", "run", "EXPR-130",
+                "--being", "test-being",
+                "--run-by", "Mini",
+            ],
+            catch_exceptions=False,
+        )
+
+        runs_dir = temp_repo / "research" / "runs" / "EXPR-130"
+        run_folders = list(runs_dir.iterdir())
+        config = yaml.safe_load((run_folders[0] / "config.yaml").read_text())
+        assert config["run_by"] == "Mini"
+
+
+# ---------------------------------------------------------------------------
+# TestExperimentStatus
+# ---------------------------------------------------------------------------
+
+
+class TestExperimentStatus:
+    """Tests for 'yurtle-kanban experiment status'."""
+
+    def test_status_no_runs(self, runner, temp_repo, hdd_config):
+        """Status with no runs should show informative message."""
+        result = runner.invoke(
+            main,
+            ["experiment", "status", "EXPR-130"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert "No runs found" in result.output
+
+    def test_status_shows_runs(self, runner, temp_repo, hdd_config):
+        """Status should show a table of existing runs."""
+        # Create two runs
+        runner.invoke(
+            main,
+            ["experiment", "run", "EXPR-130", "--being", "being-v1"],
+            catch_exceptions=False,
+        )
+        runner.invoke(
+            main,
+            ["experiment", "run", "EXPR-130", "--being", "being-v2"],
+            catch_exceptions=False,
+        )
+
+        result = runner.invoke(
+            main,
+            ["experiment", "status", "EXPR-130"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert "being-v1" in result.output
+        assert "being-v2" in result.output
+
+    def test_status_json_output(self, runner, temp_repo, hdd_config):
+        """--json should output valid JSON."""
+        import json
+
+        runner.invoke(
+            main,
+            ["experiment", "run", "EXPR-130", "--being", "test-being"],
+            catch_exceptions=False,
+        )
+
+        result = runner.invoke(
+            main,
+            ["experiment", "status", "EXPR-130", "--json"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert len(data) == 1
+        assert data[0]["being"] == "test-being"
+        assert data[0]["status"] == "running"
+
+    def test_status_auto_prefixes(self, runner, temp_repo, hdd_config):
+        """ID without EXPR- prefix should be normalized."""
+        runner.invoke(
+            main,
+            ["experiment", "run", "EXPR-130", "--being", "test-being"],
+            catch_exceptions=False,
+        )
+        result = runner.invoke(
+            main,
+            ["experiment", "status", "130"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert "test-being" in result.output
+
+
+# ---------------------------------------------------------------------------
+# TestExperimentRunService
+# ---------------------------------------------------------------------------
+
+
+class TestExperimentRunService:
+    """Tests for KanbanService experiment run methods."""
+
+    def test_create_experiment_run(self, temp_repo, hdd_config):
+        """create_experiment_run should create folder and config.yaml."""
+        service = KanbanService(hdd_config, temp_repo)
+        run_path = service.create_experiment_run(
+            expr_id="EXPR-130",
+            being="test-being-v12",
+            params={"rounds": "3"},
+            run_by="TestAgent",
+        )
+
+        assert run_path.exists()
+        config = yaml.safe_load((run_path / "config.yaml").read_text())
+        assert config["experiment"] == "EXPR-130"
+        assert config["being"] == "test-being-v12"
+        assert config["run_by"] == "TestAgent"
+        assert config["params"]["rounds"] == "3"
+        assert config["status"] == "running"
+
+    def test_get_experiment_runs_empty(self, temp_repo, hdd_config):
+        """get_experiment_runs should return empty list for non-existent experiment."""
+        service = KanbanService(hdd_config, temp_repo)
+        runs = service.get_experiment_runs("EXPR-999")
+        assert runs == []
+
+    def test_get_experiment_runs_returns_metadata(self, temp_repo, hdd_config):
+        """get_experiment_runs should return run metadata."""
+        service = KanbanService(hdd_config, temp_repo)
+        service.create_experiment_run(
+            expr_id="EXPR-130",
+            being="test-being",
+            run_by="Agent",
+        )
+
+        runs = service.get_experiment_runs("EXPR-130")
+        assert len(runs) == 1
+        assert runs[0]["being"] == "test-being"
+        assert runs[0]["status"] == "running"
+
+    def test_update_run_status(self, temp_repo, hdd_config):
+        """update_run_status should modify config.yaml."""
+        service = KanbanService(hdd_config, temp_repo)
+        run_path = service.create_experiment_run(
+            expr_id="EXPR-130",
+            being="test-being",
+        )
+
+        service.update_run_status(run_path, "complete", outcome="VALIDATED")
+
+        config = yaml.safe_load((run_path / "config.yaml").read_text())
+        assert config["status"] == "complete"
+        assert config["outcome"] == "VALIDATED"
+
+    def test_update_run_status_missing_folder(self, temp_repo, hdd_config):
+        """update_run_status should raise on missing config.yaml."""
+        service = KanbanService(hdd_config, temp_repo)
+        with pytest.raises(FileNotFoundError):
+            service.update_run_status(temp_repo / "nonexistent", "complete")
+
+    def test_get_experiment_runs_with_metrics(self, temp_repo, hdd_config):
+        """Runs with metrics.json should include outcome in metadata."""
+        import json
+
+        service = KanbanService(hdd_config, temp_repo)
+        run_path = service.create_experiment_run(
+            expr_id="EXPR-130",
+            being="test-being",
+        )
+
+        # Write metrics.json
+        metrics = {"outcome": "VALIDATED", "summary": "85.2% accuracy"}
+        (run_path / "metrics.json").write_text(json.dumps(metrics))
+
+        runs = service.get_experiment_runs("EXPR-130")
+        assert len(runs) == 1
+        assert runs[0]["outcome"] == "VALIDATED"
+        assert runs[0]["summary"] == "85.2% accuracy"
+
+
+# ---------------------------------------------------------------------------
+# TestHDDRegistry
+# ---------------------------------------------------------------------------
+
+
+def _make_experiment_file(exp_dir, expr_id, hyp_id):
+    """Create an experiment file with frontmatter."""
+    content = f'''---
+id: {expr_id}
+title: "Test Experiment"
+type: experiment
+status: draft
+hypothesis: {hyp_id}
+created: 2026-01-01
+priority: medium
+tags: []
+---
+
+# {expr_id}: Test Experiment
+'''
+    path = exp_dir / f"{expr_id}-Test-Experiment.md"
+    path.write_text(content)
+    return path
+
+
+def _make_measure_file(measure_dir, measure_id, unit="percent", category="accuracy"):
+    """Create a measure file with frontmatter."""
+    content = f'''---
+id: {measure_id}
+title: "Test Measure"
+type: measure
+status: draft
+unit: {unit}
+category: {category}
+created: 2026-01-01
+priority: medium
+tags: []
+---
+
+# {measure_id}: Test Measure
+'''
+    path = measure_dir / f"{measure_id}-Test-Measure.md"
+    path.write_text(content)
+    return path
+
+
+class TestHDDRegistry:
+    """Tests for 'yurtle-kanban hdd registry'."""
+
+    def test_registry_generates_file(self, runner, temp_repo, hdd_config):
+        """Registry command should generate REGISTRY.md."""
+        result = runner.invoke(
+            main,
+            ["hdd", "registry"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        assert "Registry written" in result.output
+
+        registry = temp_repo / "research" / "REGISTRY.md"
+        assert registry.exists()
+        content = registry.read_text()
+        assert "# HDD Research Registry" in content
+
+    def test_registry_includes_papers(self, runner, temp_repo, hdd_config):
+        """Registry should list papers with hypothesis links."""
+        _make_paper_file(temp_repo / "research" / "papers", "130")
+        _make_hypothesis_file(
+            temp_repo / "research" / "hypotheses", "H130.1", "130",
+        )
+
+        result = runner.invoke(
+            main,
+            ["hdd", "registry"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+
+        registry = temp_repo / "research" / "REGISTRY.md"
+        content = registry.read_text()
+        assert "PAPER-130" in content
+        assert "H130.1" in content
+
+    def test_registry_includes_experiments(self, runner, temp_repo, hdd_config):
+        """Registry should list experiments with hypothesis links."""
+        _make_hypothesis_file(
+            temp_repo / "research" / "hypotheses", "H130.1", "130",
+        )
+        _make_experiment_file(
+            temp_repo / "research" / "experiments", "EXPR-130", "H130.1",
+        )
+
+        result = runner.invoke(
+            main,
+            ["hdd", "registry"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+
+        registry = temp_repo / "research" / "REGISTRY.md"
+        content = registry.read_text()
+        assert "EXPR-130" in content
+
+    def test_registry_shows_orphaned(self, runner, temp_repo, hdd_config):
+        """Registry should list orphaned items (hypothesis without paper)."""
+        # Create hypothesis without a paper file
+        hyp_dir = temp_repo / "research" / "hypotheses"
+        (hyp_dir / "H999.1-Orphan.md").write_text(
+            "---\nid: H999.1\ntitle: \"Orphan\"\ntype: hypothesis\n"
+            "status: draft\ncreated: 2026-01-01\ntags: []\n---\n# Orphan\n"
+        )
+
+        result = runner.invoke(
+            main,
+            ["hdd", "registry"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+
+        registry = temp_repo / "research" / "REGISTRY.md"
+        content = registry.read_text()
+        assert "Orphaned" in content
+        assert "H999.1" in content
+
+    def test_registry_custom_output(self, runner, temp_repo, hdd_config):
+        """Registry should write to custom output path."""
+        output = str(temp_repo / "custom_registry.md")
+        result = runner.invoke(
+            main,
+            ["hdd", "registry", "--output", output],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert Path(output).exists()
+
+    def test_registry_empty(self, runner, temp_repo, hdd_config):
+        """Registry with no items should still generate valid markdown."""
+        result = runner.invoke(
+            main,
+            ["hdd", "registry"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert "0 items indexed" in result.output
+
+
+# ---------------------------------------------------------------------------
+# TestHDDValidate
+# ---------------------------------------------------------------------------
+
+
+class TestHDDValidate:
+    """Tests for 'yurtle-kanban hdd validate'."""
+
+    def test_validate_clean(self, runner, temp_repo, hdd_config):
+        """Validate with well-linked items should exit 0."""
+        _make_paper_file(temp_repo / "research" / "papers", "130")
+        _make_hypothesis_file(
+            temp_repo / "research" / "hypotheses", "H130.1", "130",
+        )
+        _make_experiment_file(
+            temp_repo / "research" / "experiments", "EXPR-130", "H130.1",
+        )
+
+        result = runner.invoke(
+            main,
+            ["hdd", "validate"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert "Validation Report" in result.output
+
+    def test_validate_missing_paper(self, runner, temp_repo, hdd_config):
+        """Hypothesis referencing non-existent paper should be an error (exit 1)."""
+        # H130.1 references PAPER-130 but the paper doesn't exist
+        _make_hypothesis_file(
+            temp_repo / "research" / "hypotheses", "H130.1", "130",
+        )
+
+        result = runner.invoke(
+            main,
+            ["hdd", "validate"],
+        )
+        assert result.exit_code == 1  # errors always cause exit 1
+        assert "not found" in result.output or "Error" in result.output
+
+    def test_validate_missing_hypothesis(self, runner, temp_repo, hdd_config):
+        """Experiment without hypothesis link should generate a warning."""
+        exp_dir = temp_repo / "research" / "experiments"
+        (exp_dir / "EXPR-999-No-Hyp.md").write_text(
+            "---\nid: EXPR-999\ntitle: \"No Hyp\"\ntype: experiment\n"
+            "status: draft\ncreated: 2026-01-01\ntags: []\n---\n# No Hyp\n"
+        )
+
+        result = runner.invoke(
+            main,
+            ["hdd", "validate"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert "Warning" in result.output or "warning" in result.output.lower()
+
+    def test_validate_strict_fails_on_warnings(self, runner, temp_repo, hdd_config):
+        """--strict should exit 1 when warnings exist."""
+        exp_dir = temp_repo / "research" / "experiments"
+        (exp_dir / "EXPR-999-No-Hyp.md").write_text(
+            "---\nid: EXPR-999\ntitle: \"No Hyp\"\ntype: experiment\n"
+            "status: draft\ncreated: 2026-01-01\ntags: []\n---\n# No Hyp\n"
+        )
+
+        result = runner.invoke(
+            main,
+            ["hdd", "validate", "--strict"],
+        )
+        assert result.exit_code != 0
+
+    def test_validate_json_output(self, runner, temp_repo, hdd_config):
+        """--json should output valid JSON report."""
+        import json
+
+        _make_paper_file(temp_repo / "research" / "papers", "130")
+        _make_hypothesis_file(
+            temp_repo / "research" / "hypotheses", "H130.1", "130",
+        )
+
+        result = runner.invoke(
+            main,
+            ["hdd", "validate", "--json"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "errors" in data
+        assert "warnings" in data
+        assert "summary" in data
+
+
+# ---------------------------------------------------------------------------
+# TestHDDCrossReferences (Service)
+# ---------------------------------------------------------------------------
+
+
+class TestHDDCrossReferences:
+    """Tests for KanbanService.get_hdd_cross_references()."""
+
+    def test_empty_repo(self, temp_repo, hdd_config):
+        """Empty repo should return empty cross-references."""
+        service = KanbanService(hdd_config, temp_repo)
+        xrefs = service.get_hdd_cross_references()
+        assert xrefs["papers"] == []
+        assert xrefs["hypotheses"] == []
+        assert xrefs["orphaned"] == []
+
+    def test_paper_hypothesis_link(self, temp_repo, hdd_config):
+        """Paper should list its hypotheses in cross-references."""
+        _make_paper_file(temp_repo / "research" / "papers", "130")
+        _make_hypothesis_file(
+            temp_repo / "research" / "hypotheses", "H130.1", "130",
+        )
+        _make_hypothesis_file(
+            temp_repo / "research" / "hypotheses", "H130.2", "130",
+        )
+
+        service = KanbanService(hdd_config, temp_repo)
+        xrefs = service.get_hdd_cross_references()
+
+        papers = xrefs["papers"]
+        assert len(papers) == 1
+        assert set(papers[0]["hypotheses"]) == {"H130.1", "H130.2"}
+
+    def test_hypothesis_experiment_link(self, temp_repo, hdd_config):
+        """Hypothesis should list its experiments."""
+        _make_hypothesis_file(
+            temp_repo / "research" / "hypotheses", "H130.1", "130",
+        )
+        _make_experiment_file(
+            temp_repo / "research" / "experiments", "EXPR-130", "H130.1",
+        )
+
+        service = KanbanService(hdd_config, temp_repo)
+        xrefs = service.get_hdd_cross_references()
+
+        hyps = xrefs["hypotheses"]
+        assert len(hyps) == 1
+        assert "EXPR-130" in hyps[0]["experiments"]
+
+    def test_orphaned_hypothesis_detected(self, temp_repo, hdd_config):
+        """Hypothesis without paper field should appear in orphaned."""
+        hyp_dir = temp_repo / "research" / "hypotheses"
+        (hyp_dir / "H999.1-Orphan.md").write_text(
+            "---\nid: H999.1\ntitle: \"Orphan\"\ntype: hypothesis\n"
+            "status: draft\ncreated: 2026-01-01\ntags: []\n---\n# Orphan\n"
+        )
+
+        service = KanbanService(hdd_config, temp_repo)
+        xrefs = service.get_hdd_cross_references()
+
+        orphaned_ids = [o["id"] for o in xrefs["orphaned"]]
+        assert "H999.1" in orphaned_ids
+
+    def test_orphaned_experiment_detected(self, temp_repo, hdd_config):
+        """Experiment without hypothesis field should appear in orphaned."""
+        exp_dir = temp_repo / "research" / "experiments"
+        (exp_dir / "EXPR-999-No-Hyp.md").write_text(
+            "---\nid: EXPR-999\ntitle: \"No Hyp\"\ntype: experiment\n"
+            "status: draft\ncreated: 2026-01-01\ntags: []\n---\n# No Hyp\n"
+        )
+
+        service = KanbanService(hdd_config, temp_repo)
+        xrefs = service.get_hdd_cross_references()
+
+        orphaned_ids = [o["id"] for o in xrefs["orphaned"]]
+        assert "EXPR-999" in orphaned_ids
+
+
+# ---------------------------------------------------------------------------
+# TestHDDValidation (Service)
+# ---------------------------------------------------------------------------
+
+
+class TestHDDValidation:
+    """Tests for KanbanService.validate_hdd_links()."""
+
+    def test_clean_validation(self, temp_repo, hdd_config):
+        """Well-linked items should produce 0 errors."""
+        _make_paper_file(temp_repo / "research" / "papers", "130")
+        _make_hypothesis_file(
+            temp_repo / "research" / "hypotheses", "H130.1", "130",
+        )
+        _make_experiment_file(
+            temp_repo / "research" / "experiments", "EXPR-130", "H130.1",
+        )
+
+        service = KanbanService(hdd_config, temp_repo)
+        report = service.validate_hdd_links()
+        assert report["summary"]["errors"] == 0
+
+    def test_broken_paper_reference(self, temp_repo, hdd_config):
+        """Hypothesis referencing non-existent paper should produce error."""
+        _make_hypothesis_file(
+            temp_repo / "research" / "hypotheses", "H130.1", "130",
+        )
+        # No PAPER-130 file
+
+        service = KanbanService(hdd_config, temp_repo)
+        report = service.validate_hdd_links()
+        error_ids = [e["id"] for e in report["errors"]]
+        assert "H130.1" in error_ids
+
+    def test_missing_hypothesis_link_warning(self, temp_repo, hdd_config):
+        """Experiment without hypothesis should produce warning."""
+        exp_dir = temp_repo / "research" / "experiments"
+        (exp_dir / "EXPR-999-No-Hyp.md").write_text(
+            "---\nid: EXPR-999\ntitle: \"No Hyp\"\ntype: experiment\n"
+            "status: draft\ncreated: 2026-01-01\ntags: []\n---\n# No Hyp\n"
+        )
+
+        service = KanbanService(hdd_config, temp_repo)
+        report = service.validate_hdd_links()
+        warning_ids = [w["id"] for w in report["warnings"]]
+        assert "EXPR-999" in warning_ids
+
+    def test_unused_measure_warning(self, temp_repo, hdd_config):
+        """Unreferenced measure should produce warning."""
+        _make_measure_file(temp_repo / "research" / "measures", "M-042")
+
+        service = KanbanService(hdd_config, temp_repo)
+        report = service.validate_hdd_links()
+        warning_ids = [w["id"] for w in report["warnings"]]
+        assert "M-042" in warning_ids


### PR DESCRIPTION
## Summary

- **Phase 3 — Experiment Run Tracking**: `experiment run` creates timestamped run folders with `config.yaml`; `experiment status` shows all runs in a Rich table with being, status, and outcome from `metrics.json`
- **Phase 4 — HDD Registry & Validation**: `hdd registry` auto-generates a cross-referenced `REGISTRY.md`; `hdd validate` checks bidirectional links between papers, hypotheses, experiments, and measures with error/warning/orphan reporting
- 35 new tests (458 total passing)

## New Commands

```bash
# Phase 3
yurtle-kanban experiment run EXPR-130 --being santiago-toddler-v12.4
yurtle-kanban experiment run EXPR-130 --being v12.4 --params "kbdd_rounds=3"
yurtle-kanban experiment status EXPR-130
yurtle-kanban experiment status EXPR-130 --json

# Phase 4
yurtle-kanban hdd registry
yurtle-kanban hdd registry --output custom/path.md --push
yurtle-kanban hdd validate
yurtle-kanban hdd validate --strict
yurtle-kanban hdd validate --json
```

## Files Changed

| File | Changes |
|------|---------|
| `src/yurtle_kanban/service.py` | +385 lines: `create_experiment_run`, `get_experiment_runs`, `update_run_status`, `get_hdd_cross_references`, `validate_hdd_links` |
| `src/yurtle_kanban/hdd_commands.py` | +349 lines: `experiment run`, `experiment status`, `hdd registry`, `hdd validate` |
| `tests/test_hdd_commands.py` | +627 lines: 35 new tests across 8 test classes |

## Test plan

- [x] All 458 tests pass (`python3.11 -m pytest tests/ -v --timeout=30`)
- [ ] Smoke test `experiment run` in nusy-product-team repo
- [ ] Smoke test `hdd registry` against real research items
- [ ] Smoke test `hdd validate` against real research items

🤖 Generated with [Claude Code](https://claude.com/claude-code)