### PR TITLE
feat: add compute_requirement as first-class WorkItem field

### DIFF
--- a/src/yurtle_kanban/models.py
+++ b/src/yurtle_kanban/models.py
@@ -131,6 +131,7 @@ class WorkItem:
     graph: Graph | None = None  # RDF graph from frontmatter + fenced blocks
     priority_rank: int | None = None  # Explicit priority rank (lower = higher priority)
     value_summary: str | None = None  # Brief value statement for prioritization
+    compute_requirement: str | None = None  # e.g. dgx-training, gpu, cpu-safe
 
     def __post_init__(self):
         if self.updated is None:
@@ -200,6 +201,7 @@ class WorkItem:
             "superseded_by": self.superseded_by,
             "priority_rank": self.priority_rank,
             "value_summary": self.value_summary,
+            "compute_requirement": self.compute_requirement,
             "triple_count": len(self.graph) if self.graph else 0,
         }
 
@@ -241,6 +243,9 @@ class WorkItem:
         if self.superseded_by:
             refs_str = ", ".join(f"<{ref}>" for ref in self.superseded_by)
             lines.append(f"   kb:supersededBy {refs_str} ;")
+
+        if self.compute_requirement:
+            lines.append(f'   kb:computeRequirement "{self.compute_requirement}" ;')
 
         # Remove trailing semicolon from last line and add period
         lines[-1] = lines[-1].rstrip(" ;") + " ."
@@ -284,6 +289,9 @@ class WorkItem:
         if self.value_summary:
             escaped = self.value_summary.replace('"', '\\"')
             lines.append(f'value_summary: "{escaped}"')
+
+        if self.compute_requirement:
+            lines.append(f"compute_requirement: {self.compute_requirement}")
 
         if self.resolution:
             lines.append(f"resolution: {self.resolution}")

--- a/src/yurtle_kanban/service.py
+++ b/src/yurtle_kanban/service.py
@@ -265,6 +265,8 @@ class KanbanService:
             if isinstance(superseded_by, str):
                 superseded_by = [s.strip() for s in superseded_by.split(",")]
 
+            compute_requirement = frontmatter.get("compute_requirement")
+
             # Parse RDF graph from frontmatter + fenced blocks
             graph = self._parse_graph(content)
 
@@ -286,6 +288,7 @@ class KanbanService:
                 graph=graph,
                 priority_rank=priority_rank,
                 value_summary=value_summary,
+                compute_requirement=compute_requirement,
             )
 
         except Exception as e:


### PR DESCRIPTION
## Summary

- Adds `compute_requirement: str | None` to `WorkItem` dataclass (e.g., `dgx-training`, `gpu`, `cpu-safe`)
- Parsed from YAML frontmatter in `_parse_file()`
- Serialized in `to_dict()`, `to_markdown()`, and `to_yurtle()` (as `kb:computeRequirement`)
- Previously only read ad-hoc via `_get_hdd_frontmatter()` in `build_cross_board_graph()`

Enables standard kanban queries like `yurtle-kanban list --json | jq '.[] | select(.compute_requirement == "dgx-training")'` for Bosun routing.

## Test plan

- [x] All 122 model/service/critical-path tests pass
- [x] Pre-existing template resolution failures unchanged (30 — unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)