### PR TITLE
feat: add --board option to list command

### DIFF
--- a/src/yurtle_kanban/cli.py
+++ b/src/yurtle_kanban/cli.py
@@ -295,11 +295,13 @@ kanban:
 @click.option("--status", "-s", help="Filter by status (backlog, ready, in_progress, review, done)")
 @click.option("--type", "-t", "item_type", help="Filter by type (feature, bug, epic, task)")
 @click.option("--assignee", "-a", help="Filter by assignee")
+@click.option("--board", "-b", "board_name", help="Filter to a specific board (multi-board mode)")
 @click.option("--json", "as_json", is_flag=True, help="Output as JSON")
 def list_items(
     status: str | None,
     item_type: str | None,
     assignee: str | None,
+    board_name: str | None,
     as_json: bool,
 ):
     """List work items."""
@@ -326,6 +328,7 @@ def list_items(
         status=status_filter,
         item_type=type_filter,
         assignee=assignee,
+        board=board_name,
     )
 
     if not items:

--- a/src/yurtle_kanban/service.py
+++ b/src/yurtle_kanban/service.py
@@ -643,12 +643,27 @@ class KanbanService:
         status: WorkItemStatus | None = None,
         item_type: WorkItemType | None = None,
         assignee: str | None = None,
+        board: str | None = None,
     ) -> list[WorkItem]:
-        """Get items with optional filters."""
-        if not self._items:
-            self.scan()
+        """Get items with optional filters.
 
-        items = list(self._items.values())
+        Args:
+            status: Filter by status
+            item_type: Filter by type
+            assignee: Filter by assignee
+            board: Filter to a specific board (multi-board mode only).
+                   If None, returns items from all boards (default behavior).
+        """
+        if board and self.config.is_multi_board:
+            board_config = self.config.get_board(board)
+            if board_config:
+                items = self._scan_board(board_config)
+            else:
+                items = []
+        else:
+            if not self._items:
+                self.scan()
+            items = list(self._items.values())
 
         if status:
             items = [i for i in items if i.status == status]

--- a/tests/test_multiboard.py
+++ b/tests/test_multiboard.py
@@ -352,6 +352,133 @@ status: in_progress
         assert "EXP-001" not in research_ids
 
 
+class TestGetItemsBoardFilter:
+    """Tests for get_items(board=...) filtering."""
+
+    @pytest.fixture
+    def multi_board_setup(self, tmp_path):
+        """Create a multi-board test environment with items on both boards."""
+        config_path = tmp_path / ".kanban" / "config.yaml"
+        config_path.parent.mkdir(parents=True)
+        config_path.write_text("""
+version: "2.0"
+boards:
+  - name: development
+    preset: nautical
+    path: kanban-work/
+  - name: research
+    preset: software
+    path: research/
+default_board: development
+""")
+
+        (tmp_path / "kanban-work" / "expeditions").mkdir(parents=True)
+        (tmp_path / "research" / "experiments").mkdir(parents=True)
+
+        (tmp_path / "kanban-work" / "expeditions" / "EXP-001-Test.md").write_text("""---
+id: EXP-001
+title: "Dev Item"
+type: expedition
+status: backlog
+---
+# Dev Item
+""")
+        (tmp_path / "kanban-work" / "expeditions" / "EXP-002-Active.md").write_text("""---
+id: EXP-002
+title: "Active Dev Item"
+type: expedition
+status: in_progress
+---
+# Active Dev Item
+""")
+        (tmp_path / "research" / "experiments" / "EXPR-101.md").write_text("""---
+id: EXPR-101
+title: "Research Experiment"
+type: feature
+status: in_progress
+---
+# Research Experiment
+""")
+        (tmp_path / "research" / "experiments" / "EXPR-102.md").write_text("""---
+id: EXPR-102
+title: "Draft Experiment"
+type: feature
+status: backlog
+---
+# Draft Experiment
+""")
+
+        config = KanbanConfig.load(config_path)
+        service = KanbanService(config, tmp_path)
+        return service
+
+    def test_get_items_no_board_returns_all(self, multi_board_setup):
+        """Without board filter, get_items returns items from all boards."""
+        items = multi_board_setup.get_items()
+        ids = {i.id for i in items}
+        assert "EXP-001" in ids
+        assert "EXP-002" in ids
+        assert "EXPR-101" in ids
+        assert "EXPR-102" in ids
+
+    def test_get_items_board_development(self, multi_board_setup):
+        """With board='development', only dev items returned."""
+        items = multi_board_setup.get_items(board="development")
+        ids = {i.id for i in items}
+        assert "EXP-001" in ids
+        assert "EXP-002" in ids
+        assert "EXPR-101" not in ids
+        assert "EXPR-102" not in ids
+
+    def test_get_items_board_research(self, multi_board_setup):
+        """With board='research', only research items returned."""
+        items = multi_board_setup.get_items(board="research")
+        ids = {i.id for i in items}
+        assert "EXPR-101" in ids
+        assert "EXPR-102" in ids
+        assert "EXP-001" not in ids
+        assert "EXP-002" not in ids
+
+    def test_get_items_board_with_status_filter(self, multi_board_setup):
+        """Board filter combines with status filter."""
+        from yurtle_kanban.models import WorkItemStatus
+        items = multi_board_setup.get_items(
+            board="research",
+            status=WorkItemStatus.IN_PROGRESS,
+        )
+        ids = {i.id for i in items}
+        assert ids == {"EXPR-101"}
+
+    def test_get_items_board_invalid_name(self, multi_board_setup):
+        """Invalid board name returns empty list."""
+        items = multi_board_setup.get_items(board="nonexistent")
+        assert items == []
+
+    def test_get_items_board_ignored_in_single_board(self, tmp_path):
+        """In single-board mode, board parameter is ignored."""
+        config_path = tmp_path / ".kanban" / "config.yaml"
+        config_path.parent.mkdir(parents=True)
+        config_path.write_text("""
+theme: software
+paths:
+  root: work/
+""")
+        (tmp_path / "work").mkdir()
+        (tmp_path / "work" / "ITEM-001.md").write_text("""---
+id: ITEM-001
+title: "Solo Item"
+type: feature
+status: backlog
+---
+# Solo
+""")
+        config = KanbanConfig.load(config_path)
+        service = KanbanService(config, tmp_path)
+        items = service.get_items(board="research")
+        assert len(items) == 1
+        assert items[0].id == "ITEM-001"
+
+
 class TestBoardForPath:
     """Tests for detecting board from path."""
 


### PR DESCRIPTION
## Summary

- Adds `-b`/`--board` option to `yurtle-kanban list` for multi-board filtering
- `yurtle-kanban list --board research --json` returns only research board items
- Backward compatible: no `--board` flag = scan all boards (existing behavior)
- In single-board mode, the parameter is silently ignored

## Motivation

EXP-1053: The Bosun morning scan needs to query both development and research boards separately. `yurtle-kanban list` previously had no way to scope to a single board — it always returned all items from all configured boards.

## Changes

| File | Change |
|------|--------|
| `cli.py` | Add `--board`/`-b` click option to `list_items()` |
| `service.py` | Add `board` param to `get_items()`, delegates to `_scan_board()` |
| `test_multiboard.py` | 6 new tests: dev filter, research filter, combined filters, invalid board, single-board compat |

## Test plan

- [x] 6 new tests in `TestGetItemsBoardFilter` — all pass
- [x] 57 total multiboard tests — all pass
- [x] Live test: `yurtle-kanban list --board research --json` → 83 items
- [x] Live test: `yurtle-kanban list --board development --json` → 708 items
- [x] Live test: `yurtle-kanban list --board research --status in_progress --json` → 5 items

🤖 Generated with [Claude Code](https://claude.com/claude-code)