### PR TITLE
feat: add --priority filter to list command

### DIFF
--- a/src/yurtle_kanban/cli.py
+++ b/src/yurtle_kanban/cli.py
@@ -295,12 +295,14 @@ kanban:
 @click.option("--status", "-s", help="Filter by status (backlog, ready, in_progress, review, done)")
 @click.option("--type", "-t", "item_type", help="Filter by type (feature, bug, epic, task)")
 @click.option("--assignee", "-a", help="Filter by assignee")
+@click.option("--priority", "-p", help="Filter by priority (critical, high, medium, low). Comma-separated for multiple.")
 @click.option("--board", "-b", "board_name", help="Filter to a specific board (multi-board mode)")
 @click.option("--json", "as_json", is_flag=True, help="Output as JSON")
 def list_items(
     status: str | None,
     item_type: str | None,
     assignee: str | None,
+    priority: str | None,
     board_name: str | None,
     as_json: bool,
 ):
@@ -324,11 +326,21 @@ def list_items(
             console.print(f"[red]Unknown type: {item_type}[/red]")
             sys.exit(1)
 
+    priority_filter = None
+    if priority:
+        valid_priorities = {"critical", "high", "medium", "low"}
+        priority_filter = [p.strip().lower() for p in priority.split(",")]
+        invalid = [p for p in priority_filter if p not in valid_priorities]
+        if invalid:
+            console.print(f"[red]Unknown priority: {', '.join(invalid)}. Valid: critical, high, medium, low[/red]")
+            sys.exit(1)
+
     items = service.get_items(
         status=status_filter,
         item_type=type_filter,
         assignee=assignee,
         board=board_name,
+        priority=priority_filter,
     )
 
     if not items:

--- a/src/yurtle_kanban/service.py
+++ b/src/yurtle_kanban/service.py
@@ -644,6 +644,7 @@ class KanbanService:
         item_type: WorkItemType | None = None,
         assignee: str | None = None,
         board: str | None = None,
+        priority: list[str] | None = None,
     ) -> list[WorkItem]:
         """Get items with optional filters.
 
@@ -653,6 +654,7 @@ class KanbanService:
             assignee: Filter by assignee
             board: Filter to a specific board (multi-board mode only).
                    If None, returns items from all boards (default behavior).
+            priority: Filter by priority level(s) (e.g. ["critical", "high"]).
         """
         if board and self.config.is_multi_board:
             board_config = self.config.get_board(board)
@@ -671,6 +673,8 @@ class KanbanService:
             items = [i for i in items if i.item_type == item_type]
         if assignee:
             items = [i for i in items if i.assignee == assignee]
+        if priority:
+            items = [i for i in items if (i.priority or "medium") in priority]
 
         return sorted(items, key=lambda i: (-i.priority_score, -i.numeric_id))
 

--- a/tests/test_priority_filter.py
+++ b/tests/test_priority_filter.py
@@ -1,0 +1,146 @@
+"""Tests for --priority filter on the list command."""
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from yurtle_kanban.cli import main
+from yurtle_kanban.config import KanbanConfig, PathConfig
+from yurtle_kanban.models import WorkItemStatus
+from yurtle_kanban.service import KanbanService
+
+
+@pytest.fixture
+def temp_repo(tmp_path):
+    """Create a minimal git repo with kanban config and items at various priorities."""
+    subprocess.run(["git", "init", "-b", "main"], cwd=tmp_path, capture_output=True, check=True)
+    subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=tmp_path, capture_output=True, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, capture_output=True, check=True)
+
+    (tmp_path / ".kanban").mkdir()
+    (tmp_path / "kanban-work" / "expeditions").mkdir(parents=True)
+
+    config = KanbanConfig(
+        theme="nautical",
+        paths=PathConfig(
+            root="kanban-work/",
+            scan_paths=["kanban-work/expeditions/"],
+        ),
+    )
+    config.save(tmp_path / ".kanban" / "config.yaml")
+
+    # Create items with different priorities
+    exp_dir = tmp_path / "kanban-work" / "expeditions"
+    (exp_dir / "EXP-001-Critical-Item.md").write_text(
+        "---\nid: EXP-001\ntitle: Critical Item\nstatus: backlog\npriority: critical\n---\n"
+    )
+    (exp_dir / "EXP-002-High-Item.md").write_text(
+        "---\nid: EXP-002\ntitle: High Item\nstatus: backlog\npriority: high\n---\n"
+    )
+    (exp_dir / "EXP-003-Medium-Item.md").write_text(
+        "---\nid: EXP-003\ntitle: Medium Item\nstatus: backlog\npriority: medium\n---\n"
+    )
+    (exp_dir / "EXP-004-Low-Item.md").write_text(
+        "---\nid: EXP-004\ntitle: Low Item\nstatus: in_progress\npriority: low\n---\n"
+    )
+    (exp_dir / "EXP-005-No-Priority.md").write_text(
+        "---\nid: EXP-005\ntitle: No Priority\nstatus: backlog\n---\n"
+    )
+
+    return tmp_path
+
+
+class TestPriorityFilterService:
+    """Test priority filtering at the service layer."""
+
+    def test_filter_single_priority(self, temp_repo):
+        config = KanbanConfig.load(temp_repo / ".kanban" / "config.yaml")
+        svc = KanbanService(config, temp_repo)
+
+        items = svc.get_items(priority=["critical"])
+        assert len(items) == 1
+        assert items[0].id == "EXP-001"
+
+    def test_filter_multiple_priorities(self, temp_repo):
+        config = KanbanConfig.load(temp_repo / ".kanban" / "config.yaml")
+        svc = KanbanService(config, temp_repo)
+
+        items = svc.get_items(priority=["critical", "high"])
+        assert len(items) == 2
+        ids = {i.id for i in items}
+        assert ids == {"EXP-001", "EXP-002"}
+
+    def test_filter_no_priority_defaults_to_medium(self, temp_repo):
+        """Items without explicit priority default to 'medium'."""
+        config = KanbanConfig.load(temp_repo / ".kanban" / "config.yaml")
+        svc = KanbanService(config, temp_repo)
+
+        items = svc.get_items(priority=["medium"])
+        ids = {i.id for i in items}
+        # EXP-003 (explicit medium) and EXP-005 (no priority → medium)
+        assert "EXP-003" in ids
+        assert "EXP-005" in ids
+
+    def test_filter_priority_with_status(self, temp_repo):
+        """Priority filter combines with status filter."""
+        config = KanbanConfig.load(temp_repo / ".kanban" / "config.yaml")
+        svc = KanbanService(config, temp_repo)
+
+        items = svc.get_items(
+            priority=["low"],
+            status=WorkItemStatus.IN_PROGRESS,
+        )
+        assert len(items) == 1
+        assert items[0].id == "EXP-004"
+
+    def test_no_priority_filter_returns_all(self, temp_repo):
+        config = KanbanConfig.load(temp_repo / ".kanban" / "config.yaml")
+        svc = KanbanService(config, temp_repo)
+
+        items = svc.get_items(priority=None)
+        assert len(items) == 5
+
+
+class TestPriorityFilterCLI:
+    """Test --priority flag via CLI runner."""
+
+    def test_cli_priority_filter(self, temp_repo, monkeypatch):
+        monkeypatch.chdir(temp_repo)
+        runner = CliRunner()
+
+        result = runner.invoke(main, ["list", "--priority", "critical", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert len(data) == 1
+        assert data[0]["id"] == "EXP-001"
+
+    def test_cli_priority_comma_separated(self, temp_repo, monkeypatch):
+        monkeypatch.chdir(temp_repo)
+        runner = CliRunner()
+
+        result = runner.invoke(main, ["list", "--priority", "critical,high", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert len(data) == 2
+        ids = {d["id"] for d in data}
+        assert ids == {"EXP-001", "EXP-002"}
+
+    def test_cli_priority_invalid_value(self, temp_repo, monkeypatch):
+        monkeypatch.chdir(temp_repo)
+        runner = CliRunner()
+
+        result = runner.invoke(main, ["list", "--priority", "urgent"])
+        assert result.exit_code != 0
+
+    def test_cli_priority_short_flag(self, temp_repo, monkeypatch):
+        monkeypatch.chdir(temp_repo)
+        runner = CliRunner()
+
+        result = runner.invoke(main, ["list", "-p", "high", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert len(data) == 1
+        assert data[0]["id"] == "EXP-002"


### PR DESCRIPTION
## Summary

- Adds `-p`/`--priority` flag to `yurtle-kanban list` for filtering items by priority level
- Supports single values (`--priority critical`) and comma-separated multiples (`--priority critical,high`)
- Items without explicit priority default to "medium" for filtering purposes
- Invalid values produce clear error messages

## Usage

```bash
# Show only critical items
yurtle-kanban list --priority critical

# Show critical and high priority items
yurtle-kanban list -p critical,high

# Combine with other filters
yurtle-kanban list --board research --type paper --priority critical,high --json
```

## Changes

- `cli.py`: Added `--priority`/`-p` option with comma-split parsing and validation
- `service.py`: Added `priority` parameter to `get_items()` filter chain
- `tests/test_priority_filter.py`: 9 tests (5 service-layer, 4 CLI-layer)

## Test plan

- [x] All 543 existing tests pass
- [x] 9 new tests cover: single priority, multiple priorities, default medium, combined filters, CLI flag, comma-separated, invalid values, short flag

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)