### PR TITLE
feat: dev board shows all item types + bump v2.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yurtle-kanban"
-version = "2.0.0"
+version = "2.0.1"
 description = "File-based kanban with a queryable knowledge graph. SPARQL, semantic search, and natural language queries over Yurtle (Turtle RDF in Markdown). Git is your database."
 readme = "README.md"
 license = "MIT"

--- a/src/yurtle_kanban/__init__.py
+++ b/src/yurtle_kanban/__init__.py
@@ -21,7 +21,7 @@ Usage:
     yurtle-kanban-mcp
 """
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 # yurtle-kanban is a graph-native product — rdflib + yurtle-rdflib are required.
 # Register the yurtle_rdflib plugin before any Graph.parse(format="yurtle") calls.

--- a/src/yurtle_kanban/export.py
+++ b/src/yurtle_kanban/export.py
@@ -278,39 +278,50 @@ def export_markdown(board: Board) -> str:
 
 
 def export_expedition_index(board: Board, min_id: int = 600) -> str:
-    """Export an enhanced expedition index with Work Trail and Dependency Tree.
+    """Export an enhanced development board index with all item types.
 
     Features:
-    - Enhanced table with Agent, Depends, For columns
+    - Expeditions table with Agent, Depends, For columns
+    - Chores and Voyages tables
     - Work Trail (items >= min_id) with dependency hierarchy
     - Dependency Tree for active development items
+    - Summary counts by type
 
     Args:
         board: The kanban board with all items
         min_id: Minimum item number for Work Trail section (default: 600)
 
     Returns:
-        Markdown formatted expedition index
+        Markdown formatted development board index
     """
     lines = [
-        "# Expedition Index",
+        "# Development Board",
         "",
         f"*Generated: {datetime.now().strftime('%Y-%m-%d %H:%M')}*",
         "",
     ]
 
-    # Filter to expedition-type items and sort by ID
+    # Group items by type
     expeditions = [
         item for item in board.items if item.item_type.value in ("expedition", "feature", "epic")
     ]
     expeditions.sort(key=lambda x: _extract_id_number(x.id), reverse=True)
 
+    chores = [item for item in board.items if item.item_type.value == "chore"]
+    chores.sort(key=lambda x: _extract_id_number(x.id), reverse=True)
+
+    voyages = [item for item in board.items if item.item_type.value == "voyage"]
+    voyages.sort(key=lambda x: _extract_id_number(x.id), reverse=True)
+
+    signals = [item for item in board.items if item.item_type.value == "signal"]
+    signals.sort(key=lambda x: _extract_id_number(x.id), reverse=True)
+
     # =========================================================================
-    # Section 1: Enhanced Expeditions Table
+    # Section 1: Expeditions
     # =========================================================================
     lines.extend(
         [
-            "## Expeditions",
+            f"## Expeditions ({len(expeditions)})",
             "",
             "| # | Title | Status | Pri | Agent | Depends | For |",
             "|---|-------|--------|-----|-------|---------|-----|",
@@ -330,9 +341,80 @@ def export_expedition_index(board: Board, min_id: int = 600) -> str:
             f"| {num} | {title} | {status} | {priority} | {agent} | {depends} | {purpose} |"
         )
 
+    lines.append("")
+
+    # =========================================================================
+    # Section 2: Voyages
+    # =========================================================================
+    if voyages:
+        lines.extend(
+            [
+                f"## Voyages ({len(voyages)})",
+                "",
+                "| # | Title | Status | Pri | Items |",
+                "|---|-------|--------|-----|-------|",
+            ]
+        )
+
+        for item in voyages:
+            num = _extract_id_number(item.id)
+            title = item.title[:55] + "..." if len(item.title) > 55 else item.title
+            status = _status_emoji(item.status)
+            priority = str(item.priority or "medium").upper()[:4]
+            related_count = len(item.related) if item.related else "-"
+
+            lines.append(f"| {num} | {title} | {status} | {priority} | {related_count} |")
+
+        lines.append("")
+
+    # =========================================================================
+    # Section 3: Chores
+    # =========================================================================
+    if chores:
+        lines.extend(
+            [
+                f"## Chores ({len(chores)})",
+                "",
+                "| # | Title | Status | Pri |",
+                "|---|-------|--------|-----|",
+            ]
+        )
+
+        for item in chores:
+            num = _extract_id_number(item.id)
+            title = item.title[:60] + "..." if len(item.title) > 60 else item.title
+            status = _status_emoji(item.status)
+            priority = str(item.priority or "medium").upper()[:4]
+
+            lines.append(f"| {num} | {title} | {status} | {priority} |")
+
+        lines.append("")
+
+    # =========================================================================
+    # Section 4: Signals
+    # =========================================================================
+    if signals:
+        lines.extend(
+            [
+                f"## Signals ({len(signals)})",
+                "",
+                "| # | Title | Status | Pri |",
+                "|---|-------|--------|-----|",
+            ]
+        )
+
+        for item in signals:
+            num = _extract_id_number(item.id)
+            title = item.title[:60] + "..." if len(item.title) > 60 else item.title
+            status = _status_emoji(item.status)
+            priority = str(item.priority or "medium").upper()[:4]
+
+            lines.append(f"| {num} | {title} | {status} | {priority} |")
+
+        lines.append("")
+
     lines.extend(
         [
-            "",
             "**Legend:** 🔄 Active | 🟢 Ready | 🟡 Blocked/Harbor | ✅ Done | ❌ Stranded",
             "",
         ]
@@ -428,6 +510,31 @@ def export_expedition_index(board: Board, min_id: int = 600) -> str:
                 "",
             ]
         )
+
+    # =========================================================================
+    # Section 6: Summary
+    # =========================================================================
+    type_counts = [
+        ("Expeditions", len(expeditions)),
+        ("Voyages", len(voyages)),
+        ("Chores", len(chores)),
+        ("Signals", len(signals)),
+    ]
+    total = sum(c for _, c in type_counts)
+
+    lines.extend(
+        [
+            "## Summary",
+            "",
+            "| Type | Count |",
+            "| --- | --- |",
+        ]
+    )
+    for name, count in type_counts:
+        if count > 0:
+            lines.append(f"| {name} | {count} |")
+    lines.append(f"| **Total** | **{total}** |")
+    lines.append("")
 
     return "\n".join(lines)
 


### PR DESCRIPTION
## Summary

- `export_expedition_index()` now includes Voyages, Chores, and Signals sections alongside Expeditions
- Each type has appropriate columns (Voyages show related item count, Chores/Signals are compact)
- Summary table at the end with counts by type
- Title changed from "Expedition Index" to "Development Board"
- Version bump 2.0.0 → 2.0.1

## Before/After

**Before:** Only Expeditions table (472 items shown out of 770 total)
**After:** All 4 types shown (473 Expeditions + 17 Voyages + 102 Chores + 6 Signals = 598 items)

## Test plan

- [x] 619 tests pass (excluding 2 pre-existing test_closed_by failures)
- [x] Manual test against nusy-product-team dev board — all types render correctly

CHORE-118

🤖 Generated with [Claude Code](https://claude.com/claude-code)