### PR TITLE
fix: accept dotted experiment IDs like EXPR-131.5

### DIFF
--- a/src/yurtle_kanban/service.py
+++ b/src/yurtle_kanban/service.py
@@ -2640,10 +2640,11 @@ class KanbanService:
             Path to the created run folder.
         """
         # Validate expr_id to prevent path traversal
-        if not re.match(r"^[A-Za-z]+-[A-Za-z0-9]+$", expr_id):
+        # Allow dotted sub-IDs like EXPR-131.5 (common for sub-experiments)
+        if not re.match(r"^[A-Za-z]+-[A-Za-z0-9]+(?:\.[A-Za-z0-9]+)*$", expr_id):
             raise ValueError(
                 f"Invalid experiment ID format: {expr_id!r} — "
-                "expected PREFIX-ID (e.g., EXPR-130)"
+                "expected PREFIX-ID (e.g., EXPR-130 or EXPR-131.5)"
             )
 
         # Resolve run_by from git config if not provided
@@ -2702,10 +2703,11 @@ class KanbanService:
             outcome, run_by, params, run_path.
         """
         # Validate expr_id to prevent path traversal
-        if not re.match(r"^[A-Za-z]+-[A-Za-z0-9]+$", expr_id):
+        # Allow dotted sub-IDs like EXPR-131.5 (common for sub-experiments)
+        if not re.match(r"^[A-Za-z]+-[A-Za-z0-9]+(?:\.[A-Za-z0-9]+)*$", expr_id):
             raise ValueError(
                 f"Invalid experiment ID format: {expr_id!r} — "
-                "expected PREFIX-ID (e.g., EXPR-130)"
+                "expected PREFIX-ID (e.g., EXPR-130 or EXPR-131.5)"
             )
         runs_base = self.repo_root / "research" / "runs" / expr_id
         if not runs_base.exists():

--- a/tests/test_hdd_commands.py
+++ b/tests/test_hdd_commands.py
@@ -1156,6 +1156,38 @@ class TestExperimentRunService:
         with pytest.raises(FileNotFoundError):
             service.update_run_status(temp_repo / "nonexistent", "complete")
 
+    def test_create_experiment_run_dotted_id(self, temp_repo, hdd_config):
+        """create_experiment_run should accept dotted sub-IDs like EXPR-131.5."""
+        service = KanbanService(hdd_config, temp_repo)
+        run_path = service.create_experiment_run(
+            expr_id="EXPR-131.5",
+            being="test-being-v12",
+            run_by="TestAgent",
+        )
+        assert run_path.exists()
+        config = yaml.safe_load((run_path / "config.yaml").read_text())
+        assert config["experiment"] == "EXPR-131.5"
+
+    def test_get_experiment_runs_dotted_id(self, temp_repo, hdd_config):
+        """get_experiment_runs should accept dotted sub-IDs like EXPR-131.5."""
+        service = KanbanService(hdd_config, temp_repo)
+        service.create_experiment_run(
+            expr_id="EXPR-131.5",
+            being="test-being",
+            run_by="Agent",
+        )
+        runs = service.get_experiment_runs("EXPR-131.5")
+        assert len(runs) == 1
+
+    def test_create_experiment_run_rejects_path_traversal(self, temp_repo, hdd_config):
+        """create_experiment_run should reject IDs with path traversal."""
+        service = KanbanService(hdd_config, temp_repo)
+        with pytest.raises(ValueError, match="Invalid experiment ID format"):
+            service.create_experiment_run(
+                expr_id="../etc/passwd",
+                being="test-being",
+            )
+
     def test_get_experiment_runs_with_metrics(self, temp_repo, hdd_config):
         """Runs with metrics.json should include outcome in metadata."""
         import json


### PR DESCRIPTION
## Summary
- Updated experiment ID validation regex to accept dotted sub-IDs (e.g., `EXPR-131.5`)
- Both `create_experiment_run()` and `get_experiment_runs()` now handle `EXPR-131.5` format
- Path traversal protection preserved — still rejects `../` and special characters

## Test plan
- [x] `test_create_experiment_run_dotted_id` — creates run folder for `EXPR-131.5`
- [x] `test_get_experiment_runs_dotted_id` — retrieves runs for `EXPR-131.5`
- [x] `test_create_experiment_run_rejects_path_traversal` — still blocks `../etc/passwd`
- [x] All existing tests pass

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)